### PR TITLE
Improve handling of openpgp keyserver default

### DIFF
--- a/cmd/csaf_provider/config.go
+++ b/cmd/csaf_provider/config.go
@@ -13,7 +13,7 @@ const (
 	defaultConfigPath = "/usr/lib/casf/config.toml"
 	defaultFolder     = "/var/www/"
 	defaultWeb        = "/var/www/html"
-	defaultPGPURL     = "http://pgp.mit.edu/pks/lookup?search=${KEY}&op=index"
+	defaultOpenPGPURL = "https://openpgp.circl.lu/pks/lookup?search=${KEY}&op=index"
 )
 
 type config struct {
@@ -22,7 +22,7 @@ type config struct {
 	Web             string `toml:"web"`
 	TLPs            []tlp  `toml:"tlps"`
 	UploadSignature bool   `toml:"upload_signature"`
-	PGPURL          string `toml:"pgp_url"`
+	OpenPGPURL      string `toml:"openpgp_url"`
 	Domain          string `toml:"domain"`
 	NoPassphrase    bool   `toml:"no_passphrase"`
 }
@@ -54,8 +54,8 @@ func (t *tlp) UnmarshalText(text []byte) error {
 	return fmt.Errorf("invalid config TLP value: %v", string(text))
 }
 
-func (cfg *config) GetPGPURL(key string) string {
-	return strings.ReplaceAll(cfg.PGPURL, "${KEY}", key)
+func (cfg *config) GetOpenPGPURL(key string) string {
+	return strings.ReplaceAll(cfg.OpenPGPURL, "${KEY}", key)
 }
 
 func loadConfig() (*config, error) {
@@ -86,8 +86,8 @@ func loadConfig() (*config, error) {
 		cfg.TLPs = []tlp{tlpCSAF, tlpWhite, tlpGreen, tlpAmber, tlpRed}
 	}
 
-	if cfg.PGPURL == "" {
-		cfg.PGPURL = defaultPGPURL
+	if cfg.OpenPGPURL == "" {
+		cfg.OpenPGPURL = defaultOpenPGPURL
 	}
 
 	return &cfg, nil

--- a/cmd/csaf_provider/controller.go
+++ b/cmd/csaf_provider/controller.go
@@ -339,7 +339,7 @@ func (c *controller) upload(rw http.ResponseWriter, r *http.Request) {
 			// TODO: Check for conflicts.
 			pmd.Publisher = ex.publisher
 
-			pmd.SetPGP(fingerprint, c.cfg.GetPGPURL(fingerprint))
+			pmd.SetPGP(fingerprint, c.cfg.GetOpenPGPURL(fingerprint))
 
 			return nil
 		}); err != nil {


### PR DESCRIPTION
 * Use a default public keyserver from the new emerging keyservers
   network that sync each other, listed from https://spider.pgpkeys.eu/ .
 * Rename "PGP" to "OpenPGP" in the url parameter to refer to the open
   standard RFC 4880.