### PR TITLE
No need for io.Copy when writing to hash.

### DIFF
--- a/cmd/csaf_provider/files.go
+++ b/cmd/csaf_provider/files.go
@@ -1,19 +1,17 @@
 package main
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"crypto/sha512"
 	"fmt"
 	"hash"
-	"io"
 	"io/ioutil"
 	"os"
 )
 
 func writeHash(fname, name string, h hash.Hash, data []byte) error {
 
-	if _, err := io.Copy(h, bytes.NewReader(data)); err != nil {
+	if _, err := h.Write(data); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
There is no need to use  io.Copy  when writing to a hash.