### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,49 @@
-# Simple Make file to build csaf_distribution components
+# Makefile to build csaf_distribution components
 
-SHELL=/bin/bash
+SHELL = /bin/bash
 BUILD = go build
-MKDIR = mkdir -p bin
+MKDIR = mkdir -p
 
-.PHONY: build build_win build_tag clean
+.PHONY: build build_linux build_win tag_checked_out mostlyclean
 
 all:
-	@echo choose a target from: build build_linux build_win build_tag clean
+	@echo choose a target from: build build_linux build_win mostlyclean
+	@echo prepend \`make BUILDTAG=1\` to checkout the highest git tag before building
+	@echo or set BUILDTAG to a specific tag
 
-# Build the binaries for GNU/linux and place them under bin/ directory.
-build_linux:
-	@$(MKDIR)
-	@echo "Bulding binaries for GNU/Linux ..."
-	@$(BUILD) -o ./bin/ -v ./cmd/...
-
-# Build the binaries for windows (cross build) and place them under bin/ directory.
-build_win:
-	@$(MKDIR)
-	@echo "Bulding binaries for windows (cross build) ..."
-	@env GOARCH=amd64 GOOS=windows $(BUILD)  -o ./bin/ -v ./cmd/...
-
-# Build the binaries for both GNU/linux and Windows and place them under bin/ directory.
+# Build all binaries
 build: build_linux build_win
 
-# Build the binaries from the latest github tag.
-TAG = $(shell git tag --sort=-version:refname | head -n 1)
-build_tag:
-ifeq ($(TAG),)
-	@echo "No Tag found"
-else
-	@git checkout -q tags/${TAG};
-	@echo $(buildMsg)
-	@$(BUILD) -o ./bin/ -v ./cmd/...;
-	@env GOOS=windows $(BUILD)  -o ./ -v ./cmd/...
-	@git checkout -q main
+# if BUILDTAG == 1 set it to the highest git tag
+ifeq ($(strip $(BUILDTAG)),1)
+override BUILDTAG = $(shell git tag --sort=-version:refname | head -n 1)
 endif
 
-# Remove bin/ directory
-clean:
-	@rm -rf bin/
+ifdef BUILDTAG
+# add the git tag checkout to the requirements of our build targets
+build_linux build_win: tag_checked_out
+endif
+
+tag_checked_out:
+	$(if $(strip $(BUILDTAG)),,$(error no git tag found))
+	git checkout -q tags/${BUILDTAG}
+	@echo Don\'t forget that we are in checked out tag $(BUILDTAG) now.
 
 
+# Build binaries and place them under bin-$(GOOS)-$(GOARCH)
+# Using 'Target-specific Variable Values' to specify the build target system
+
+GOARCH = amd64
+build_linux: GOOS = linux
+build_win: GOOS = windows
+
+build_linux build_win:
+	$(eval BINDIR = bin-$(GOOS)-$(GOARCH)/ )
+	$(MKDIR) $(BINDIR)
+	env GOARCH=$(GOARCH) GOOS=$(GOOS) $(BUILD) -o $(BINDIR) -v ./cmd/...
+
+
+# Remove bin-*-* directories
+mostlyclean:
+	rm -rf ./bin-*-*
+	@echo Files in \`go env GOCACHE\` remain.


### PR DESCRIPTION
 * Change mechanics to use a variable to indicate if a tag build is wanted. Add ability to specify tag explictely.
 * Use variables to have only one build recipe.
 * Place binaries in target specific bin- directories.
 * Do not return to main branch as it may not be the original branch we
   were on. Turn this into a warning.