### PR TITLE
Factor out summary extraction from advisories.

### DIFF
--- a/util/json.go
+++ b/util/json.go
@@ -9,7 +9,12 @@
 package util
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+
+	"github.com/PaesslerAG/gval"
+	"github.com/PaesslerAG/jsonpath"
 )
 
 // ReMarshalJSON transforms data from src to dst via JSON marshalling.
@@ -19,4 +24,35 @@ func ReMarshalJSON(dst, src interface{}) error {
 		return err
 	}
 	return json.Unmarshal(intermediate, dst)
+}
+
+// PathEval is a helper to evaluate JSON paths on documents.
+type PathEval struct {
+	builder gval.Language
+	exprs   map[string]gval.Evaluable
+}
+
+// NewPathEval creates a new PathEval.
+func NewPathEval() *PathEval {
+	return &PathEval{
+		builder: gval.Full(jsonpath.Language()),
+		exprs:   map[string]gval.Evaluable{},
+	}
+}
+
+// Eval evalutes expression expr on document doc.
+// Returns the result of the expression.
+func (pe *PathEval) Eval(expr string, doc interface{}) (interface{}, error) {
+	if doc == nil {
+		return nil, errors.New("no document to extract data from")
+	}
+	eval := pe.exprs[expr]
+	if eval == nil {
+		var err error
+		if eval, err = pe.builder.NewEvaluable(expr); err != nil {
+			return nil, err
+		}
+		pe.exprs[expr] = eval
+	}
+	return eval(context.Background(), doc)
 }


### PR DESCRIPTION
Extracting an essential summary from an advisory is need in provider and aggregator.
So this code is factored out to be useful in both cases.