### PR TITLE
Fixing `CASF' typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Following options are supported:
 | -a, --action=[upload\|create]              | Action to perform (default: upload)                                                        |
 | -u, --url=URL                              | URL of the CSAF provider (default:https:<span></span>//localhost/cgi-bin/csaf_provider.go) |
 | -t, --tlp=[csaf\|white\|green\|amber\|red] | TLP of the feed (default: csaf)                                                            |
-| -x, --external-signed                      | CASF files are signed externally. Assumes .asc files beside CSAF files                     |
+| -x, --external-signed                      | CSAF files are signed externally. Assumes .asc files beside CSAF files                     |
 | -k, --key=KEY-FILE                         | OpenPGP key to sign the CSAF files                                                         |
 | -p, --password=PASSWORD                    | Authentication password for accessing the CSAF provider                                    |
 | -P, --passphrase=PASSPHRASE                | Passphrase to unlock the OpenPGP key                                                       |

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -775,7 +775,7 @@ func extractProviderURL(r io.Reader) (string, error) {
 		if strings.HasPrefix(line, csaf) {
 			line = strings.TrimSpace(line[len(csaf):])
 			if !strings.HasPrefix(line, "https://") {
-				return "", errors.New("CASF: found in security.txt, but does not start with https://")
+				return "", errors.New("CSAF: found in security.txt, but does not start with https://")
 			}
 			return line, nil
 		}

--- a/cmd/csaf_provider/config.go
+++ b/cmd/csaf_provider/config.go
@@ -23,7 +23,7 @@ import (
 const (
 	// The environment name, that contains the path to the config file.
 	configEnv          = "CSAF_CONFIG"
-	defaultConfigPath  = "/usr/lib/casf/config.toml"                                        // Default path to the config file.
+	defaultConfigPath  = "/usr/lib/csaf/config.toml"                                        // Default path to the config file.
 	defaultFolder      = "/var/www/"                                                        // Default folder path.
 	defaultWeb         = "/var/www/html"                                                    // Default web path.
 	defaultOpenPGPURL  = "https://openpgp.circl.lu/pks/lookup?op=get&search=${FINGERPRINT}" // Default OpenPGP URL.

--- a/cmd/csaf_uploader/main.go
+++ b/cmd/csaf_uploader/main.go
@@ -3,10 +3,10 @@
 //
 // SPDX-License-Identifier: MIT
 //
-// SPDX-FileCopyrightText: 2021 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
-// Software-Engineering: 2021 Intevation GmbH <https://intevation.de>
+// SPDX-FileCopyrightText: 2022 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2022 Intevation GmbH <https://intevation.de>
 
-// Implemnts a command line tool that loads csaf documents to a trusted provider
+// Implements a command line tool that uploads csaf documents to csaf_provider.
 package main
 
 import (
@@ -34,7 +34,7 @@ type options struct {
 	Action         string `short:"a" long:"action" choice:"upload" choice:"create" default:"upload" description:"Action to perform"`
 	URL            string `short:"u" long:"url" description:"URL of the CSAF provider" default:"https://localhost/cgi-bin/csaf_provider.go" value-name:"URL"`
 	TLP            string `short:"t" long:"tlp" choice:"csaf" choice:"white" choice:"green" choice:"amber" choice:"red" default:"csaf" description:"TLP of the feed"`
-	ExternalSigned bool   `short:"x" long:"external-signed" description:"CASF files are signed externally. Assumes .asc files beside CSAF files."`
+	ExternalSigned bool   `short:"x" long:"external-signed" description:"CSAF files are signed externally. Assumes .asc files beside CSAF files."`
 	NoSchemaCheck  bool   `short:"s" long:"no-schema-check" description:"Do not check files against CSAF JSON schema locally."`
 
 	Key        *string `short:"k" long:"key" description:"OpenPGP key to sign the CSAF files" value-name:"KEY-FILE"`

--- a/csaf/models.go
+++ b/csaf/models.go
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: MIT
 //
-// SPDX-FileCopyrightText: 2021 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
-// Software-Engineering: 2021 Intevation GmbH <https://intevation.de>
+// SPDX-FileCopyrightText: 2022 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2022 Intevation GmbH <https://intevation.de>
 
 package csaf
 
@@ -72,13 +72,13 @@ type Distribution struct {
 type TimeStamp time.Time
 
 // Fingerprint is the fingerprint of a OpenPGP key used to sign
-// the CASF documents.
+// the CSAF documents.
 type Fingerprint string
 
 var fingerprintPattern = patternUnmarshal(`^[0-9a-fA-F]{40,}$`)
 
 // PGPKey is location and the fingerprint of the key
-// used to sign the CASF documents.
+// used to sign the CSAF documents.
 type PGPKey struct {
 	Fingerprint Fingerprint `json:"fingerprint,omitempty"`
 	URL         *string     `json:"url"` // required


### PR DESCRIPTION
 * Bump copyright year 2021 -> 2022 on a few files.