### PR TITLE
Use TLS client certificate for authentication (Uploader)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Following options are supported:
 | -I, --passphrase-interacive                | Enter passphrase interactively                                                             |
 | -c, --config=INI-FILE                      | Path to config ini file                                                                    |
 | --insecure                                 | Do not check TSL certificates from provider                                                |
+| --client-cert                              | TLS client certificate file                                                                |
+| --client-key                               | TLS client private key file                                                                |
 | -h, --help                                 | Show help                                                                                  |
 
 E.g. creating the initial directiories and files

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Following options are supported:
 | -I, --passphrase-interacive                | Enter passphrase interactively                                                             |
 | -c, --config=INI-FILE                      | Path to config ini file                                                                    |
 | --insecure                                 | Do not check TSL certificates from provider                                                |
-| --client-cert                              | TLS client certificate file                                                                |
-| --client-key                               | TLS client private key file                                                                |
+| --client-cert                              | TLS client certificate file (PEM encoded data)                                             |
+| --client-key                               | TLS client private key file (PEM encoded data)                                             |
 | -h, --help                                 | Show help                                                                                  |
 
 E.g. creating the initial directiories and files

--- a/cmd/csaf_uploader/main.go
+++ b/cmd/csaf_uploader/main.go
@@ -379,6 +379,11 @@ func main() {
 		check(readInteractive("Enter OpenPGP passphrase: ", &opts.Passphrase))
 	}
 
+	if (opts.ClientCert != nil && opts.ClientKey == nil) || (opts.ClientCert == nil && opts.ClientKey != nil) {
+		log.Println("Both client-key and client-cert options must be set for the authentication.")
+		return
+	}
+
 	p, err := newProcessor(&opts)
 	check(err)
 

--- a/cmd/csaf_uploader/main.go
+++ b/cmd/csaf_uploader/main.go
@@ -40,6 +40,8 @@ type options struct {
 	Key        *string `short:"k" long:"key" description:"OpenPGP key to sign the CSAF files" value-name:"KEY-FILE"`
 	Password   *string `short:"p" long:"password" description:"Authentication password for accessing the CSAF provider" value-name:"PASSWORD"`
 	Passphrase *string `short:"P" long:"passphrase" description:"Passphrase to unlock the OpenPGP key" value-name:"PASSPHRASE"`
+	ClientCert *string `long:"client-cert" description:"TLS client certificate file" value-name:"CERT-FILE"`
+	ClientKey  *string `long:"client-key" description:"TLS client private key file" value-name:"KEY-FILE"`
 
 	PasswordInteractive   bool `short:"i" long:"password-interactive" description:"Enter password interactively" no-ini:"true"`
 	PassphraseInteractive bool `short:"I" long:"passphrase-interacive" description:"Enter passphrase interactively" no-ini:"true"`
@@ -111,17 +113,29 @@ func newProcessor(opts *options) (*processor, error) {
 	return &p, nil
 }
 
-// httpClient initializes the http client according
-// to the "Insecure" flag option and returns it.
+// httpClient initializes the http.Client according to the "Insecure" flag
+// and the TLS client files for authentication and returns it.
 func (p *processor) httpClient() *http.Client {
 	var client http.Client
+	var tlsConfig tls.Config
+
 	if p.opts.Insecure {
-		client.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-		}
+		tlsConfig.InsecureSkipVerify = true
 	}
+
+	if p.opts.ClientCert != nil && p.opts.ClientKey != nil {
+		cert, err := tls.LoadX509KeyPair(*p.opts.ClientCert, *p.opts.ClientKey)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	client.Transport = &http.Transport{
+		TLSClientConfig: &tlsConfig,
+	}
+
 	return &client
 }
 
@@ -257,7 +271,7 @@ func (p *processor) uploadRequest(filename string) (*http.Request, error) {
 	return req, nil
 }
 
-// process attemps to upload a file filename to the server.
+// process attemps to upload a file to the server.
 // It prints the response messages.
 func (p *processor) process(filename string) error {
 

--- a/cmd/csaf_uploader/main.go
+++ b/cmd/csaf_uploader/main.go
@@ -40,8 +40,8 @@ type options struct {
 	Key        *string `short:"k" long:"key" description:"OpenPGP key to sign the CSAF files" value-name:"KEY-FILE"`
 	Password   *string `short:"p" long:"password" description:"Authentication password for accessing the CSAF provider" value-name:"PASSWORD"`
 	Passphrase *string `short:"P" long:"passphrase" description:"Passphrase to unlock the OpenPGP key" value-name:"PASSPHRASE"`
-	ClientCert *string `long:"client-cert" description:"TLS client certificate file" value-name:"CERT-FILE"`
-	ClientKey  *string `long:"client-key" description:"TLS client private key file" value-name:"KEY-FILE"`
+	ClientCert *string `long:"client-cert" description:"TLS client certificate file (file must contain PEM encoded data)" value-name:"CERT-FILE.crt"`
+	ClientKey  *string `long:"client-key" description:"TLS client private key file (file must contain PEM encoded data)" value-name:"KEY-FILE.pem"`
 
 	PasswordInteractive   bool `short:"i" long:"password-interactive" description:"Enter password interactively" no-ini:"true"`
 	PassphraseInteractive bool `short:"I" long:"passphrase-interacive" description:"Enter passphrase interactively" no-ini:"true"`

--- a/cmd/csaf_uploader/main.go
+++ b/cmd/csaf_uploader/main.go
@@ -40,8 +40,8 @@ type options struct {
 	Key        *string `short:"k" long:"key" description:"OpenPGP key to sign the CSAF files" value-name:"KEY-FILE"`
 	Password   *string `short:"p" long:"password" description:"Authentication password for accessing the CSAF provider" value-name:"PASSWORD"`
 	Passphrase *string `short:"P" long:"passphrase" description:"Passphrase to unlock the OpenPGP key" value-name:"PASSPHRASE"`
-	ClientCert *string `long:"client-cert" description:"TLS client certificate file (file must contain PEM encoded data)" value-name:"CERT-FILE.crt"`
-	ClientKey  *string `long:"client-key" description:"TLS client private key file (file must contain PEM encoded data)" value-name:"KEY-FILE.pem"`
+	ClientCert *string `long:"client-cert" description:"TLS client certificate file (PEM encoded data)" value-name:"CERT-FILE.crt"`
+	ClientKey  *string `long:"client-key" description:"TLS client private key file (PEM encoded data)" value-name:"KEY-FILE.pem"`
 
 	PasswordInteractive   bool `short:"i" long:"password-interactive" description:"Enter password interactively" no-ini:"true"`
 	PassphraseInteractive bool `short:"I" long:"passphrase-interacive" description:"Enter passphrase interactively" no-ini:"true"`


### PR DESCRIPTION
* Add "client-cert" and "client-key" flag options to allow the uploader to use
TLS client certificate for authentication with the provider.