### PR TITLE
Use TLS client certificate for authentication (Checker)

### DIFF
--- a/cmd/csaf_checker/main.go
+++ b/cmd/csaf_checker/main.go
@@ -24,9 +24,11 @@ import (
 var reportHTML string
 
 type options struct {
-	Output   string `short:"o" long:"output" description:"File name of the generated report" value-name:"REPORT-FILE"`
-	Format   string `short:"f" long:"format" choice:"json" choice:"html" description:"Format of report" default:"json"`
-	Insecure bool   `long:"insecure" description:"Do not check TSL certificates from provider"`
+	Output     string  `short:"o" long:"output" description:"File name of the generated report" value-name:"REPORT-FILE"`
+	Format     string  `short:"f" long:"format" choice:"json" choice:"html" description:"Format of report" default:"json"`
+	Insecure   bool    `long:"insecure" description:"Do not check TSL certificates from provider"`
+	ClientCert *string `long:"client-cert" description:"TLS client certificate file" value-name:"CERT-FILE"`
+	ClientKey  *string `long:"client-key" description:"TLS client private key file" value-name:"KEY-FILE"`
 }
 
 func errCheck(err error) {


### PR DESCRIPTION
* Add "client-cert" and "client-key" flag options to allow the checker to use TLS client certificate for authentication.