### PR TITLE
Improve checker's reporting texts

### DIFF
--- a/cmd/csaf_checker/reporters.go
+++ b/cmd/csaf_checker/reporters.go
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: MIT
 //
-// SPDX-FileCopyrightText: 2021 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
-// Software-Engineering: 2021 Intevation GmbH <https://intevation.de>
+// SPDX-FileCopyrightText: 2022 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2022 Intevation GmbH <https://intevation.de>
 
 package main
 
@@ -49,7 +49,7 @@ func (r *tlsReporter) report(p *processor, domain *Domain) {
 		return
 	}
 	if len(p.noneTLS) == 0 {
-		req.message("All tested URLs were https.")
+		req.message("All tested URLs were HTTPS.")
 		return
 	}
 
@@ -60,7 +60,7 @@ func (r *tlsReporter) report(p *processor, domain *Domain) {
 		i++
 	}
 	sort.Strings(urls)
-	req.message("Following none https URLs were used:")
+	req.message("Following non-HTTPS URLs were used:")
 	req.message(urls...)
 }
 
@@ -91,7 +91,7 @@ func (r *providerMetadataReport) report(p *processor, domain *Domain) {
 		return
 	}
 	if len(p.badProviderMetadatas) == 0 {
-		req.message("No problems with provider metadata.")
+		req.message("Found good provider metadata.")
 		return
 	}
 	req.Messages = p.badProviderMetadatas
@@ -104,7 +104,7 @@ func (r *securityReporter) report(p *processor, domain *Domain) {
 		return
 	}
 	if len(p.badSecurities) == 0 {
-		req.message("No problems with security.txt found.")
+		req.message("Found good security.txt.")
 		return
 	}
 	req.Messages = p.badSecurities
@@ -114,18 +114,20 @@ func (r *wellknownMetadataReporter) report(_ *processor, domain *Domain) {
 	// TODO: Implement me!
 	req := r.requirement(domain)
 	_ = req
+	req.message("(Not checked, missing implementation.)")
 }
 
 func (r *dnsPathReporter) report(_ *processor, domain *Domain) {
 	// TODO: Implement me!
 	req := r.requirement(domain)
 	_ = req
+	req.message("(Not checked, missing implementation.)")
 }
 
 func (r *oneFolderPerYearReport) report(p *processor, domain *Domain) {
 	req := r.requirement(domain)
 	if !used(p.badFolders) {
-		req.message("No checks if file are in right folders were performed.")
+		req.message("No checks if files are in right folders were performed.")
 		return
 	}
 	if len(p.badFolders) == 0 {
@@ -142,7 +144,7 @@ func (r *indexReporter) report(p *processor, domain *Domain) {
 		return
 	}
 	if len(p.badIndices) == 0 {
-		req.message("No problems with index.txt found.")
+		req.message("Found good index.txt.")
 		return
 	}
 	req.Messages = p.badIndices
@@ -155,7 +157,7 @@ func (r *changesReporter) report(p *processor, domain *Domain) {
 		return
 	}
 	if len(p.badChanges) == 0 {
-		req.message("No problems with changes.csv found.")
+		req.message("Found good changes.csv.")
 		return
 	}
 	req.Messages = p.badChanges
@@ -195,11 +197,11 @@ func (r *signaturesReporter) report(p *processor, domain *Domain) {
 func (r *publicPGPKeyReporter) report(p *processor, domain *Domain) {
 	req := r.requirement(domain)
 	if !used(p.badPGPs) {
-		req.message("No PGP keys loaded.")
+		req.message("No public OpenPGP keys loaded.")
 		return
 	}
 	req.Messages = p.badPGPs
 	if len(p.keys) > 0 {
-		req.message(fmt.Sprintf("%d PGP key(s) loaded successfully.", len(p.keys)))
+		req.message(fmt.Sprintf("%d public OpenPGP key(s) loaded.", len(p.keys)))
 	}
 }

--- a/cmd/csaf_checker/reporters.go
+++ b/cmd/csaf_checker/reporters.go
@@ -113,14 +113,12 @@ func (r *securityReporter) report(p *processor, domain *Domain) {
 func (r *wellknownMetadataReporter) report(_ *processor, domain *Domain) {
 	// TODO: Implement me!
 	req := r.requirement(domain)
-	_ = req
 	req.message("(Not checked, missing implementation.)")
 }
 
 func (r *dnsPathReporter) report(_ *processor, domain *Domain) {
 	// TODO: Implement me!
 	req := r.requirement(domain)
-	_ = req
 	req.message("(Not checked, missing implementation.)")
 }
 


### PR DESCRIPTION
 * Remove minor typos.
 * Go upper case for HTTPS as this is more common.
 * Make texts indicating a good result start with somethink else
   than "No", this removes an indirection in thinking and also offers
   a visible difference.
 * Bump copyright year to 2022.
 * Do PGP to "public OpenPGP keys" while at the reporters.go file
   while at it (to make merging easier).
 * Use an explicit message to indicate that a check is not done because
   of a missing implementation.