### PR TITLE
Improve integration test uploadToProvider.sh

### DIFF
--- a/docs/scripts/uploadToProvider.sh
+++ b/docs/scripts/uploadToProvider.sh
@@ -12,7 +12,6 @@
 
 set -e
 
-
 # assumes that the following script only downloads file with filenames
 # following https://docs.oasis-open.org/csaf/csaf/v2.0/cs01/csaf-v2.0-cs01.html#51-filename
 # which are save to process further
@@ -20,11 +19,11 @@ set -e
 
 TLPs=("white" "green" "amber" "red")
 COUNTER=0
-for f in $(ls csaf_examples);
-    do
-        ../../bin-linux-amd64/csaf_uploader -a upload -t ${TLPs[$COUNTER]} \
-        -u https://localhost:8443/cgi-bin/csaf_provider.go --insecure -P security123 \
-        --client-cert ~/devca1/testclient1.crt --client-key ~/devca1/testclient1-key.pem \
-        ./csaf_examples/"$f";
-        let COUNTER++
-    done;
+for f in $(ls csaf_examples); do
+    ../../bin-linux-amd64/csaf_uploader --insecure -P security123 -a upload \
+        -t ${TLPs[$((COUNTER++ % 4))]} \
+        -u https://localhost:8443/cgi-bin/csaf_provider.go \
+        --client-cert ~/devca1/testclient1.crt \
+        --client-key ~/devca1/testclient1-key.pem \
+        ./csaf_examples/"$f"
+done


### PR DESCRIPTION
 * Remove `let` from the script as it will return 1 (signalling an error) on the
   first iteration, which will stop the script when in `set -e` mode.
   It also is unnecessary, as the increment can be done at the place of
   usage directly.
 * Added a "remainder aka modulo" division, otherwise there will be no
   TLP option set, once we run out of the four entries in the TLSs
   list.
 * (Style) remove superfluous semicolons.