### PR TITLE
Fetch the lastest Go version for test on Ubuntu.

### DIFF
--- a/docs/scripts/prepareUbuntuInstanceForITests.sh
+++ b/docs/scripts/prepareUbuntuInstanceForITests.sh
@@ -9,5 +9,6 @@ set -e
 apt install -y make bash sed tar git nginx fcgiwrap gnutls-bin
 
 # Install Go from binary distribution
-curl -O https://storage.googleapis.com/golang/go1.18.linux-amd64.tar.gz
-tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
+latest_go="$(curl https://go.dev/VERSION\?m=text).linux-amd64.tar.gz"
+curl -O https://dl.google.com/go/$latest_go
+tar -C /usr/local -xzf $latest_go


### PR DESCRIPTION
Use the latest Go Version for testing.

Before the version was hard-coded to 1.18. We are currently at 1.18.1 and it will change
in the future. The PR fetches the latest version.