### PR TITLE
For issue #83

### DIFF
--- a/cmd/csaf_provider/create.go
+++ b/cmd/csaf_provider/create.go
@@ -185,7 +185,7 @@ func createProviderMetadata(c *config, wellknownCSAF string) error {
 		return err
 	}
 	pm := csaf.NewProviderMetadataDomain(c.CanonicalURLPrefix, c.modelTLPs())
-	pm.Publisher = c.Publisher
+	c.ProviderMetaData.apply(pm)
 
 	// Set OpenPGP key.
 	key, err := c.loadCryptoKey()

--- a/docs/provider-setup.md
+++ b/docs/provider-setup.md
@@ -136,6 +136,9 @@ Provider has many config options described as following:
  - no_validation: Validate the uploaded CSAF document against the JSON schema. Default: `false`.
  - no_web_ui: Disable the web interface. Default: `false`.
  - dynamic_provider_metadata: Take the publisher from the CSAF document. Default: `false`.
- - publisher: Set the publisher. Default: `{"category"= "vendor", "name"= "Example", "namespace"= "https://example.com"}`.
+ - provider_metadata: Configure the provider metadata.
+ - provider_metadata.list_on_CSAF_aggregators: List on aggregators
+ - provider_metadata.mirror_on_CSAF_aggregators: Mirror on aggregators
+ - provider_metadata.publisher: Set the publisher. Default: `{"category"= "vendor", "name"= "Example", "namespace"= "https://example.com"}`.
  - upload_limit: Set the upload limit  size of the file. Default: `50 MiB`.
  - issuer: The issuer of the CA, which if set, restricts the writing permission and the accessing to the web-interface to only the client certificates signed with this CA.


### PR DESCRIPTION
The branch provider-listed-mirrorred2 implements this.
In the config there is a new optional table provider_metadata with
bool fields list_on_CSAF_aggregators and mirror_on_CSAF_aggregators
which are both are optional. If not set the defaults of the standard are used (true).

The publisher field of the config is moved into the provider_metadata table
as it is on the same level as list and mirror options in the generated provider_metadata.json
file.