### PR TITLE
Disable summary from fixed notes

### DIFF
--- a/cmd/csaf_provider/actions.go
+++ b/cmd/csaf_provider/actions.go
@@ -266,11 +266,14 @@ func (c *controller) upload(r *http.Request) (interface{}, error) {
 				Type: "application/json",
 				Src:  csafURL,
 			}
-			if ex.Summary != "" {
-				e.Summary = &csaf.Summary{Content: ex.Summary}
-			} else {
-				e.Summary = nil
-			}
+			e.Summary = nil
+			/*
+				if ex.Summary != "" {
+					e.Summary = &csaf.Summary{Content: ex.Summary}
+				} else {
+					e.Summary = nil
+				}
+			*/
 
 			// Sort by descending updated order.
 			rolie.SortEntriesByUpdated()

--- a/csaf/summary.go
+++ b/csaf/summary.go
@@ -31,8 +31,8 @@ type AdvisorySummary struct {
 	Publisher          *Publisher
 	InitialReleaseDate time.Time
 	CurrentReleaseDate time.Time
-	// Summary            string
 	TLPLabel           string
+	// Summary            string
 }
 
 // NewAdvisorySummary creates a summary from an advisory doc

--- a/csaf/summary.go
+++ b/csaf/summary.go
@@ -31,7 +31,7 @@ type AdvisorySummary struct {
 	Publisher          *Publisher
 	InitialReleaseDate time.Time
 	CurrentReleaseDate time.Time
-	Summary            string
+	// Summary            string
 	TLPLabel           string
 }
 
@@ -51,7 +51,7 @@ func NewAdvisorySummary(
 		{Expr: titleExpr, Action: util.StringMatcher(&e.Title)},
 		{Expr: currentReleaseDateExpr, Action: util.TimeMatcher(&e.CurrentReleaseDate, time.RFC3339)},
 		{Expr: initialReleaseDateExpr, Action: util.TimeMatcher(&e.InitialReleaseDate, time.RFC3339)},
-		{Expr: summaryExpr, Action: util.StringMatcher(&e.Summary)},
+		//{Expr: summaryExpr, Action: util.StringMatcher(&e.Summary)},
 		{Expr: tlpLabelExpr, Action: util.StringMatcher(&e.TLPLabel)},
 		{Expr: publisherExpr, Action: util.ReMarshalMatcher(e.Publisher)},
 	}, doc); err != nil {


### PR DESCRIPTION
 * Comment out compiling the summary and requiring document.notes to fix main provider.