### PR TITLE
Improve release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,38 +6,23 @@ on:
 
 jobs:
   releases-matrix:
-    name: Release Go Binary
+    name: Release Go binaries
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [linux, windows]
-        goarch: [amd64]
     steps:
-    - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.25
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        goos: ${{ matrix.goos }}
-        goarch: ${{ matrix.goarch }}
-        goversion: "latest"
-        build_flags: -v
-        project_path: ./cmd/csaf_checker
-        binary_name: csaf_checker
-    - uses: wangyoucao577/go-release-action@v1.25
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        goos: ${{ matrix.goos }}
-        goarch: ${{ matrix.goarch }}
-        goversion: "latest"
-        build_flags: -v
-        project_path: ./cmd/csaf_provider
-        binary_name: csaf_provider
-    - uses: wangyoucao577/go-release-action@v1.25
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        goos: ${{ matrix.goos }}
-        goarch: ${{ matrix.goarch }}
-        goversion: "latest"
-        build_flags: -v
-        project_path: ./cmd/csaf_uploader
-        binary_name: csaf_uploader
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+            go-version: '^1.18.2'
+
+      - name: Build
+        run: make dist
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v1
+        with:
+            files: |
+                dist/csaf_distribution-*.zip
+                dist/csaf_distribution-*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-            # make sure that we checkou tags for git describe
-            fetch-depth: 0
+            ref: ${{ github.event.release.tag_name }}
 
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-            fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-            ref: ${{ github.event.release.tag_name }}
+            ref: 0
 
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-            ref: 0
+            fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+            # make sure that we checkou tags for git describe
+            fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,9 @@ tag_checked_out:
 # into a semver version. For this we increase the PATCH number, so that
 # any commit after a tag is considered newer than the semver from the tag
 # without an optional 'v'
-GITDESC := $(shell git describe)
+# Note we need `--tags` because github release only creates lightweight tags
+#   (see feature request https://github.com/github/feedback/discussions/4924)
+GITDESC := $(shell git describe --tags)
 GITDESCPATCH := $(shell echo '$(GITDESC)' | sed -E 's/v?[0-9]+\.[0-9]+\.([0-9]+)[-+]?.*/\1/')
 SEMVERPATCH := $(shell echo $$(( $(GITDESCPATCH) + 1 )))
 # Hint: The regexp in the next line only matches if there is a hyphen (`-`)

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,11 @@ build_linux build_win:
 DISTDIR := csaf_distribution-$(SEMVER)
 dist: build_linux build_win
 	mkdir -p dist
-	mkdir dist/$(DISTDIR)-windows-amd64
-	cp -r README.md docs bin-windows-amd64 dist/$(DISTDIR)-windows-amd64
+	mkdir -p dist/$(DISTDIR)-windows-amd64/bin-windows-amd64
+	cp README.md dist/$(DISTDIR)-windows-amd64
+	cp bin-windows-amd64/csaf_uploader.exe bin-windows-amd64/csaf_checker.exe dist/$(DISTDIR)-windows-amd64/bin-windows-amd64/
+	mkdir -p dist/$(DISTDIR)-windows-amd64/docs
+	#cp docs/csaf_uploader.md docs/csaf_checker.md dist/$(DISTDIR)-windows-amd64/docs
 	mkdir dist/$(DISTDIR)-gnulinux-amd64
 	cp -r README.md docs bin-linux-amd64 dist/$(DISTDIR)-gnulinux-amd64
 	cd dist/ ; zip -r $(DISTDIR)-windows-amd64.zip $(DISTDIR)-windows-amd64/

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,9 @@ GITDESC := $(shell git describe)
 GITDESCPATCH := $(shell echo '$(GITDESC)' | sed -E 's/v?[0-9]+\.[0-9]+\.([0-9]+)[-+]?.*/\1/')
 SEMVERPATCH := $(shell echo $$(( $(GITDESCPATCH) + 1 )))
 # Hint: The regexp in the next line only matches if there is a hyphen (`-`)
-#       and we can assume that git describe has added a string after the tag
-SEMVER := $(shell echo '$(GITDESC)' | sed -E 's/v?([0-9]+\.[0-9]+\.)([0-9]+)(-.*)/\1$(SEMVERPATCH)\3/' )
+#       followed by a number, by which we assume that git describe
+#       has added a string after the tag
+SEMVER := $(shell echo '$(GITDESC)' | sed -E 's/v?([0-9]+\.[0-9]+\.)([0-9]+)(-[1-9].*)/\1$(SEMVERPATCH)\3/' )
 testsemver:
 	@echo from \'$(GITDESC)\' transformed to \'$(SEMVER)\'
 


### PR DESCRIPTION
* Add only uploader and checker binaries and basic documentation to windows dist archive.
* Improve Makefile to be able to use github lightweight git tags for release version calculation.
* Change github action to use the `make dist` target for asset uploading.