### PR TITLE
Remove redundant brackets.

### DIFF
--- a/cmd/csaf_checker/main.go
+++ b/cmd/csaf_checker/main.go
@@ -146,7 +146,7 @@ func main() {
 		return
 	}
 
-	if (opts.ClientCert != nil && opts.ClientKey == nil) || (opts.ClientCert == nil && opts.ClientKey != nil) {
+	if opts.ClientCert != nil && opts.ClientKey == nil || opts.ClientCert == nil && opts.ClientKey != nil {
 		log.Println("Both client-key and client-cert options must be set for the authentication.")
 		return
 	}

--- a/cmd/csaf_uploader/main.go
+++ b/cmd/csaf_uploader/main.go
@@ -392,7 +392,7 @@ func main() {
 		check(readInteractive("Enter OpenPGP passphrase: ", &opts.Passphrase))
 	}
 
-	if (opts.ClientCert != nil && opts.ClientKey == nil) || (opts.ClientCert == nil && opts.ClientKey != nil) {
+	if opts.ClientCert != nil && opts.ClientKey == nil || opts.ClientCert == nil && opts.ClientKey != nil {
 		log.Println("Both client-key and client-cert options must be set for the authentication.")
 		return
 	}


### PR DESCRIPTION
Remove redundant brackets via `gofmt -r '(a) -> a' -w *.go`.