### PR TITLE
Issue hash and signature URLs of advisories in ROLIE feeds, too. 

### DIFF
--- a/cmd/csaf_aggregator/indices.go
+++ b/cmd/csaf_aggregator/indices.go
@@ -166,10 +166,11 @@ func (w *worker) writeROLIE(label string, summaries []summary) error {
 			Titel:     s.summary.Title,
 			Published: csaf.TimeStamp(s.summary.InitialReleaseDate),
 			Updated:   csaf.TimeStamp(s.summary.CurrentReleaseDate),
-			Link: []csaf.Link{{
-				Rel:  "self",
-				HRef: csafURL,
-			}},
+			Link: []csaf.Link{
+				{Rel: "self", HRef: csafURL},
+				{Rel: "hash", HRef: csafURL + ".sha512"},
+				{Rel: "signature", HRef: csafURL + ".asc"},
+			},
 			Format: format,
 			Content: csaf.Content{
 				Type: "application/json",

--- a/cmd/csaf_aggregator/indices.go
+++ b/cmd/csaf_aggregator/indices.go
@@ -168,6 +168,7 @@ func (w *worker) writeROLIE(label string, summaries []summary) error {
 			Updated:   csaf.TimeStamp(s.summary.CurrentReleaseDate),
 			Link: []csaf.Link{
 				{Rel: "self", HRef: csafURL},
+				{Rel: "hash", HRef: csafURL + ".sha256"},
 				{Rel: "hash", HRef: csafURL + ".sha512"},
 				{Rel: "signature", HRef: csafURL + ".asc"},
 			},

--- a/cmd/csaf_aggregator/mirror.go
+++ b/cmd/csaf_aggregator/mirror.go
@@ -88,7 +88,7 @@ func (w *worker) handleROLIE(
 				log.Printf("Loading ROLIE feed failed: %v.", err)
 				continue
 			}
-			files := resolveURLs(rfeed.Files(), feedBaseURL)
+			files := resolveURLs(rfeed.Files("self"), feedBaseURL)
 			if err := process(feed.TLPLabel, files); err != nil {
 				return err
 			}

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -545,7 +545,7 @@ func (p *processor) processROLIEFeed(feed string) error {
 	}
 
 	// Extract the CSAF files from feed.
-	files := rfeed.Files()
+	files := rfeed.Files("self")
 
 	if err := p.integrity(files, base, rolieMask, p.badProviderMetadata.add); err != nil &&
 		err != errContinue {

--- a/cmd/csaf_provider/actions.go
+++ b/cmd/csaf_provider/actions.go
@@ -255,10 +255,11 @@ func (c *controller) upload(r *http.Request) (interface{}, error) {
 			e.Titel = ex.Title
 			e.Published = csaf.TimeStamp(ex.InitialReleaseDate)
 			e.Updated = csaf.TimeStamp(ex.CurrentReleaseDate)
-			e.Link = []csaf.Link{{
-				Rel:  "self",
-				HRef: csafURL,
-			}}
+			e.Link = []csaf.Link{
+				{Rel: "self", HRef: csafURL},
+				{Rel: "hash", HRef: csafURL + ".sha512"},
+				{Rel: "signature", HRef: csafURL + ".asc"},
+			}
 			e.Format = csaf.Format{
 				Schema:  "https://docs.oasis-open.org/csaf/csaf/v2.0/csaf_json_schema.json",
 				Version: "2.0",

--- a/cmd/csaf_provider/actions.go
+++ b/cmd/csaf_provider/actions.go
@@ -257,6 +257,7 @@ func (c *controller) upload(r *http.Request) (interface{}, error) {
 			e.Updated = csaf.TimeStamp(ex.CurrentReleaseDate)
 			e.Link = []csaf.Link{
 				{Rel: "self", HRef: csafURL},
+				{Rel: "hash", HRef: csafURL + ".sha256"},
 				{Rel: "hash", HRef: csafURL + ".sha512"},
 				{Rel: "signature", HRef: csafURL + ".asc"},
 			}

--- a/csaf/rolie.go
+++ b/csaf/rolie.go
@@ -104,11 +104,13 @@ func (rf *ROLIEFeed) EntryByID(id string) *Entry {
 }
 
 // Files extracts the files from the feed.
-func (rf *ROLIEFeed) Files() []string {
+func (rf *ROLIEFeed) Files(filter string) []string {
 	var files []string
 	for _, f := range rf.Feed.Entry {
 		for i := range f.Link {
-			files = append(files, f.Link[i].HRef)
+			if link := &f.Link[i]; link.Rel == filter {
+				files = append(files, link.HRef)
+			}
 		}
 	}
 	return files


### PR DESCRIPTION
For #74.