### PR TITLE
Improve nginx setup docs

### DIFF
--- a/docs/client-certificate-setup.md
+++ b/docs/client-certificate-setup.md
@@ -6,7 +6,7 @@ a web browser.
 ### Configure nginx
 Assuming the relevant server block is in `/etc/nginx/sites-enabled/default` and the CA used to verify the client certificates is under `/etc/ssl/`,
 adjust the content of the `server{}` block like shown in the following example:
-<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/scripts/TLSClientConfigsForITest.sh&lines=25-40) -->
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/scripts/TLSClientConfigsForITest.sh&lines=25-38) -->
 <!-- The below code snippet is automatically added from ../docs/scripts/TLSClientConfigsForITest.sh -->
 ```sh
         ssl_client_certificate '${SSL_CLIENT_CERTIFICATE}'; # e.g. ssl_client_certificate /etc/ssl/rootca-cert.pem;

--- a/docs/scripts/TLSClientConfigsForITest.sh
+++ b/docs/scripts/TLSClientConfigsForITest.sh
@@ -33,9 +33,7 @@ echo '
             autoindex on;
             # in this location access is only allowed with client certs
             if  ($ssl_client_verify != SUCCESS){
-                # we use status code 404 == "Not Found", because we do
-                # not want to reveal if files within this location exist or not.
-                return 404;
+                return 403;
             }
        }
 '> ~/${FOLDERNAME}/clientCertificateConfigs.txt


### PR DESCRIPTION
 * Change nginx config to return 403 on unauthorized access to
   the non-white TLP locations. We cannot hide the existence anyway,
   as it is listed in the provider-metadata.json, even when restricted.