### PR TITLE
Change OpenPGP signatures to be without headers

### DIFF
--- a/cmd/csaf_aggregator/mirror.go
+++ b/cmd/csaf_aggregator/mirror.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ProtonMail/gopenpgp/v2/armor"
+	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 	"github.com/csaf-poc/csaf_distribution/csaf"
 	"github.com/csaf-poc/csaf_distribution/util"
@@ -490,7 +492,8 @@ func (w *worker) sign(data []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return sig.GetArmored()
+	return armor.ArmorWithTypeAndCustomHeaders(
+		sig.Data, constants.PGPSignatureHeader, "", "")
 }
 
 func (w *worker) mirrorFiles(tlpLabel *csaf.TLPLabel, files []string) error {

--- a/cmd/csaf_provider/actions.go
+++ b/cmd/csaf_provider/actions.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ProtonMail/gopenpgp/v2/armor"
+	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 	"github.com/csaf-poc/csaf_distribution/csaf"
 	"github.com/csaf-poc/csaf_distribution/util"
@@ -112,7 +114,8 @@ func (c *controller) handleSignature(
 		return "", nil, err
 	}
 
-	armored, err := sig.GetArmored()
+	armored, err := armor.ArmorWithTypeAndCustomHeaders(
+		sig.Data, constants.PGPSignatureHeader, "", "")
 	return armored, key, err
 }
 

--- a/cmd/csaf_uploader/main.go
+++ b/cmd/csaf_uploader/main.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ProtonMail/gopenpgp/v2/armor"
+	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 	"github.com/csaf-poc/csaf_distribution/csaf"
 	"github.com/csaf-poc/csaf_distribution/util"
@@ -239,7 +241,8 @@ func (p *processor) uploadRequest(filename string) (*http.Request, error) {
 		if err != nil {
 			return nil, err
 		}
-		armored, err := sig.GetArmored()
+		armored, err := armor.ArmorWithTypeAndCustomHeaders(
+			sig.Data, constants.PGPSignatureHeader, "", "")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
 * Change options when creating the armored version of the signature
   to leave out the optional headers, which would be `Version:`
   and `Comment:`, as it is considered uncommon for a while now to
   set these.