### PR TITLE
Add documentation

### DIFF
--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -1,5 +1,5 @@
 `csaf_provider` implements the CGI interface for webservers
-and reads its configuration from a TOML file.
+and reads its configuration from a TOML file. Syntax and usage for TOML (Tom's Obvious Minimal Language) can be found under the website https://toml.io/en/.
 The [setup docs](../README.md#setup-trusted-provider)
 explain how to wire this up with nginx and where the config file lives.
 

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -27,4 +27,4 @@ Following options are supported in the config file:
  - provider_metadata: Configure the provider metadata.
  - provider_metadata.list_on_CSAF_aggregators: List on aggregators
  - provider_metadata.mirror_on_CSAF_aggregators: Mirror on aggregators
- - provider_metadata.publisher: Set the publisher. Default: `{"category"= "vendor", "name"= "Example Company", "namespace"= "https://example.com", "issuing_authority"= "Example", "contact_details"= "examplename@examplemail.com"}`.
+ - provider_metadata.publisher: Set the publisher. Default: `{"category"= "vendor", "name"= "Example Company", "namespace"= "https://example.com", "issuing_authority"= "We at Example Company are responsible for publishing and maintaining Product Y.", "contact_details"= "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."}`.

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -27,4 +27,4 @@ Following options are supported in the config file:
  - provider_metadata: Configure the provider metadata.
  - provider_metadata.list_on_CSAF_aggregators: List on aggregators
  - provider_metadata.mirror_on_CSAF_aggregators: Mirror on aggregators
- - provider_metadata.publisher: Set the publisher. Default: `{"category"= "vendor", "name"= "Example Company", "namespace"= "https://example.com"}`.
+ - provider_metadata.publisher: Set the publisher. Default: `{"category"= "vendor", "name"= "Example Company", "namespace"= "https://example.com", "issuing_authority"= "Example", "contact_details"= "examplename@examplemail.com"}`.

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -1,5 +1,5 @@
 `csaf_provider` implements the CGI interface for webservers
-and reads its configuration from a TOML file. Syntax and usage for TOML (Tom's Obvious Minimal Language) can be found under the website https://toml.io/en/.
+and reads its configuration from a [TOML](https://toml.io/en/) file.
 The [setup docs](../README.md#setup-trusted-provider)
 explain how to wire this up with nginx and where the config file lives.
 


### PR DESCRIPTION
Added missing examples for already implemented issuing_authorities and contact_details to provider_metadata.publisher in docs/csaf_provider.md. Clarified the TOML definition and linked the toml.io website where Syntax etc. for toml can be looked up.