### PR TITLE
Jh toml update

### DIFF
--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -1,5 +1,5 @@
 `csaf_provider` implements the CGI interface for webservers
-and reads its configuration from a TOML file.
+and reads its configuration from a TOML file. Syntax and usage for TOML (Tom's Obvious Minimal Language) can be found under the website https://toml.io/en/.
 The [setup docs](../README.md#setup-trusted-provider)
 explain how to wire this up with nginx and where the config file lives.
 

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -27,4 +27,4 @@ Following options are supported in the config file:
  - provider_metadata: Configure the provider metadata.
  - provider_metadata.list_on_CSAF_aggregators: List on aggregators
  - provider_metadata.mirror_on_CSAF_aggregators: Mirror on aggregators
- - provider_metadata.publisher: Set the publisher. Default: `{"category"= "vendor", "name"= "Example Company", "namespace"= "https://example.com", "issuing_authority"= "Example", "contact_details"= "examplename@examplemail.com"}`.
+ - provider_metadata.publisher: Set the publisher. Default: `{"category"= "vendor", "name"= "Example Company", "namespace"= "https://example.com", "issuing_authority"= "We at Example Company are responsible for publishing and maintaining Product Y.", "contact_details"= "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."}`.

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -27,4 +27,9 @@ Following options are supported in the config file:
  - provider_metadata: Configure the provider metadata.
  - provider_metadata.list_on_CSAF_aggregators: List on aggregators
  - provider_metadata.mirror_on_CSAF_aggregators: Mirror on aggregators
- - provider_metadata.publisher: Set the publisher. Default: `{"category"= "vendor", "name"= "Example Company", "namespace"= "https://example.com", "issuing_authority"= "We at Example Company are responsible for publishing and maintaining Product Y.", "contact_details"= "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."}`.
+ - provider_metadata.publisher: Set the publisher. Default: `[provider_metadata.publisher]
+category = "vendor"
+name = "Example Company"
+namespace = "https://example.com"
+issuing_authority = "We at Example Company are responsible for publishing and maintaining Product Y."
+contact_details = "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."`.

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -32,5 +32,5 @@ category = "vendor"
 name = "Example Company"
 namespace = "https://example.com"
 issuing_authority = "We at Example Company are responsible for publishing and maintaining Product Y."
-contact_details = "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."```
+contact_details = "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."
 

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -1,7 +1,5 @@
-`csaf_provider` implements the CGI interface for webservers
-and reads its configuration from a TOML file. Syntax and usage for TOML (Tom's Obvious Minimal Language) can be found under the website https://toml.io/en/.
-The [setup docs](../README.md#setup-trusted-provider)
-explain how to wire this up with nginx and where the config file lives.
+`csaf_provider` implements the CGI interface for webservers and reads its configuration from a [TOML](https://toml.io/en/) file.
+The [setup docs](../README.md#setup-trusted-provider) explain how to wire this up with nginx and where the config file lives.
 
 ## Provider options
 
@@ -27,9 +25,11 @@ Following options are supported in the config file:
  - provider_metadata: Configure the provider metadata.
  - provider_metadata.list_on_CSAF_aggregators: List on aggregators
  - provider_metadata.mirror_on_CSAF_aggregators: Mirror on aggregators
- - provider_metadata.publisher: Set the publisher. Default: `[provider_metadata.publisher]
+ - provider_metadata.publisher: Set the publisher. Default: 
+`[provider_metadata.publisher]
 category = "vendor"
 name = "Example Company"
 namespace = "https://example.com"
 issuing_authority = "We at Example Company are responsible for publishing and maintaining Product Y."
 contact_details = "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."`.
+

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -26,10 +26,10 @@ Following options are supported in the config file:
  - provider_metadata.list_on_CSAF_aggregators: List on aggregators
  - provider_metadata.mirror_on_CSAF_aggregators: Mirror on aggregators
  - provider_metadata.publisher: Set the publisher. Default:  
-`[provider_metadata.publisher]\
-category = "vendor"\
-name = "Example Company"\
-namespace = "https://example.com"\ 
-issuing_authority = "We at Example Company are responsible for publishing and maintaining Product Y."\ 
-contact_details = "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."`
+```toml [provider_metadata.publisher]
+category = "vendor"
+name = "Example Company"
+namespace = "https://example.com"
+issuing_authority = "We at Example Company are responsible for publishing and maintaining Product Y."
+contact_details = "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."```
 

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -27,4 +27,4 @@ Following options are supported in the config file:
  - provider_metadata: Configure the provider metadata.
  - provider_metadata.list_on_CSAF_aggregators: List on aggregators
  - provider_metadata.mirror_on_CSAF_aggregators: Mirror on aggregators
- - provider_metadata.publisher: Set the publisher. Default: `{"category"= "vendor", "name"= "Example Company", "namespace"= "https://example.com"}`.
+ - provider_metadata.publisher: Set the publisher. Default: `{"category"= "vendor", "name"= "Example Company", "namespace"= "https://example.com", "issuing_authority"= "Example", "contact_details"= "examplename@examplemail.com"}`.

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -26,10 +26,10 @@ Following options are supported in the config file:
  - provider_metadata.list_on_CSAF_aggregators: List on aggregators
  - provider_metadata.mirror_on_CSAF_aggregators: Mirror on aggregators
  - provider_metadata.publisher: Set the publisher. Default:  
-[provider_metadata.publisher]\
+`[provider_metadata.publisher]\
 category = "vendor"\
 name = "Example Company"\
 namespace = "https://example.com"\ 
 issuing_authority = "We at Example Company are responsible for publishing and maintaining Product Y."\ 
-contact_details = "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."
+contact_details = "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."`
 

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -26,10 +26,10 @@ Following options are supported in the config file:
  - provider_metadata.list_on_CSAF_aggregators: List on aggregators
  - provider_metadata.mirror_on_CSAF_aggregators: Mirror on aggregators
  - provider_metadata.publisher: Set the publisher. Default: 
-`[provider_metadata.publisher]
-category = "vendor"
-name = "Example Company"
-namespace = "https://example.com"
-issuing_authority = "We at Example Company are responsible for publishing and maintaining Product Y."
-contact_details = "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."`.
+`[provider_metadata.publisher]  
+category = "vendor"  
+name = "Example Company"  
+namespace = "https://example.com"  
+issuing_authority = "We at Example Company are responsible for publishing and maintaining Product Y."  
+contact_details = "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."`
 

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -25,11 +25,11 @@ Following options are supported in the config file:
  - provider_metadata: Configure the provider metadata.
  - provider_metadata.list_on_CSAF_aggregators: List on aggregators
  - provider_metadata.mirror_on_CSAF_aggregators: Mirror on aggregators
- - provider_metadata.publisher: Set the publisher. Default: 
-`[provider_metadata.publisher]  
-category = "vendor"  
-name = "Example Company"  
-namespace = "https://example.com"  
-issuing_authority = "We at Example Company are responsible for publishing and maintaining Product Y."  
-contact_details = "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."`
+ - provider_metadata.publisher: Set the publisher. Default:  
+[provider_metadata.publisher]\
+category = "vendor"\
+name = "Example Company"\
+namespace = "https://example.com"\ 
+issuing_authority = "We at Example Company are responsible for publishing and maintaining Product Y."\ 
+contact_details = "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."
 

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -26,7 +26,8 @@ Following options are supported in the config file:
  - provider_metadata.list_on_CSAF_aggregators: List on aggregators
  - provider_metadata.mirror_on_CSAF_aggregators: Mirror on aggregators
  - provider_metadata.publisher: Set the publisher. Default:  
-```toml [provider_metadata.publisher]
+```toml 
+[provider_metadata.publisher]
 category = "vendor"
 name = "Example Company"
 namespace = "https://example.com"


### PR DESCRIPTION
Exchange inline tables for standard tables in the TOML-part of docs/csaf_provider.md.

Inline tables should only be used for tables that easily fit into one line. Using standard tables improves readability.
Both inline and standard tables have been tested and work. 