### PR TITLE
Add forgotten validation for metadata

### DIFF
--- a/csaf/models.go
+++ b/csaf/models.go
@@ -319,6 +319,24 @@ func (a *Aggregator) Validate() error {
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaller interface.
+func (mdv *MetadataVersion) UnmarshalText(data []byte) error {
+	s, err := metadataVersionPattern(data)
+	if err == nil {
+		*mdv = MetadataVersion(s)
+	}
+	return err
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaller interface.
+func (mdr *MetadataRole) UnmarshalText(data []byte) error {
+	s, err := metadataRolePattern(data)
+	if err == nil {
+		*mdr = MetadataRole(s)
+	}
+	return err
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaller interface.
 func (ac *AggregatorCategory) UnmarshalText(data []byte) error {
 	s, err := aggregatorCategoryPattern(data)
 	if err == nil {


### PR DESCRIPTION
Add validation of MetadataVersion and MetadataRole when loading JSON models.
That must be an oversight from the early days of the models.