### PR TITLE
Enhancement and clarification of provider documentation

### DIFF
--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -32,7 +32,7 @@ An example TOML file with all config options and default values:
 # Let user send password with the request, if set to true the input-field in the web interface will be disappeared.
 #no_passphrase = false
 
-# Validate the uploaded CSAF document against the JSON schema.
+# Skip validation of the uploaded CSAF document against the JSON schema. Default: false.
 #no_validation = false
 
 # Disable the web interface.

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -5,33 +5,64 @@ explain how to wire this up with nginx and where the config file lives.
 
 
 ## Provider options
+An example TOML file with all config options and default values:
 
-Following options are supported in the config file:
-
- - password: Authentication password for accessing the CSAF provider.
- - openpgp_public_key: The public OpenPGP key. Default: `/ust/lib/csaf/openpgp_public.asc`
- - openpgp_private_key: The private OpenPGP key. Default: `/ust/lib/csaf/openpgp_private.asc`
- - folder: Specify the root folder. Default: `/var/www/`.
- - web: Specify the web folder. Default: `/var/www/html`.
- - upload_signature: Send signature with the request, an additional input-field in the web interface will be shown to let user enter an ascii armored signature. Default: `false`.
- - canonical_url_prefix: start of the URL where contents shall be accessible from the internet. Default: `https://$SERVER_NAME`.
- - no_passphrase: Let user send password with the request, if set to true the input-field in the web interface will be disappeared. Default: `false`.
- - no_validation: Validate the uploaded CSAF document against the JSON schema. Default: `false`.
- - no_web_ui: Disable the web interface. Default: `false`.
- - dynamic_provider_metadata: Take the publisher from the CSAF document. Default: `false`.
- - upload_limit: Set the upload limit size of a file in bytes. Default: `52428800` (aka 50 MiB).
- - issuer: The issuer of the CA, which if set, restricts the writing permission and the accessing to the web-interface to only the client certificates signed with this CA.
- - tlps: Set the allowed TLP comming with the upload request (one or more of "csaf", "white", "amber", "green", "red").
-   The "csaf" selection lets the provider takes the value from the CSAF document.
-   These affects the list items in the web interface.
-   Default: `["csaf", "white", "amber", "green", "red"]`.
- - provider_metadata: Configure the provider metadata.
- - provider_metadata.list_on_CSAF_aggregators: List on aggregators
- - provider_metadata.mirror_on_CSAF_aggregators: Mirror on aggregators
- - remote_validator: Use a remote validator service. Not used by default.
-   `{ "url" = "http://localhost:3000", "presets" = ["mandatory"], "cache" = "/var/lib/csaf/validations.db" }`
- - provider_metadata.publisher: Set the publisher. Default:
 ```toml
+#Authentication password for accessing the CSAF provider.
+#password = ""
+
+# Path to public OpenPGP key.
+#openpgp_public_key = "usr/lib/csaf/openpgp_public.asc"
+
+# The private OpenPGP key
+#openpgp_private_key = "/usr/lib/csaf/openpgp_private.asc"
+
+# Specify the root folder `
+#folder = "/var/www/"
+
+# Specify the web folder
+#web = "/var/www/html"
+
+# Send signature with the request, an additional input-field in the web interface will be shown to let user enter an ascii armored signature.
+#upload_signature = false
+
+# start of the URL where contents shall be accessible from the internet.
+#canonical_url_prefix  = "https://$SERVER_NAME"
+
+# Let user send password with the request, if set to true the input-field in the web interface will be disappeared.
+#no_passphrase = false
+
+# Validate the uploaded CSAF document against the JSON schema.
+#no_validation = false
+
+# Disable the web interface.
+#no_web_ui = false
+
+# Take the publisher from the CSAF document.
+#dynamic_provider_metadata = false
+
+# Set the upload limit size of a file in bytes. Default: `52428800` (aka 50 MiB).
+#upload_limit =  52428800
+
+# The issuer of the CA, which if set, restricts the writing permission and the accessing to the web-interface to only the client certificates signed with this CA.
+#issuer = ""
+
+# Set the allowed TLP comming with the upload request (one or more of "csaf", "white", "amber", "green", "red").
+#   The "csaf" selection lets the provider takes the value from the CSAF document.
+#   These affects the list items in the web interface.
+#tlps = ["csaf", "white", "amber", "green", "red"]`
+
+# Use a remote validator service. Not used by default.
+#[remote_validator]
+#url = "http://localhost:3000"
+#presets = ["mandatory"]
+#cache = "/var/lib/csaf/validations.db"
+
+[provider_metadata]
+# List on aggregators
+list_on_CSAF_aggregators = true
+#Mirror on aggregators
+mirror_on_CSAF_aggregators = true
 [provider_metadata.publisher]
 category = "vendor"
 name = "Example Company"


### PR DESCRIPTION
I transfered the documentation to TOML syntax, so it can be directly used as example config.