### PR TITLE
Clarification of authentication configuration

### DIFF
--- a/cmd/csaf_uploader/main.go
+++ b/cmd/csaf_uploader/main.go
@@ -41,7 +41,7 @@ type options struct {
 	NoSchemaCheck  bool   `short:"s" long:"no-schema-check" description:"Do not check files against CSAF JSON schema locally."`
 
 	Key        *string `short:"k" long:"key" description:"OpenPGP key to sign the CSAF files" value-name:"KEY-FILE"`
-	Password   *string `short:"p" long:"password" description:"Authentication password for accessing the CSAF provider" value-name:"PASSWORD"`
+	Password   *string `short:"p" long:"password" description:"Authentication password for accessing the CSAF provider. (Password is only used, if no client certificate for authentication is configured.)" value-name:"PASSWORD"`
 	Passphrase *string `short:"P" long:"passphrase" description:"Passphrase to unlock the OpenPGP key" value-name:"PASSPHRASE"`
 	ClientCert *string `long:"client-cert" description:"TLS client certificate file (PEM encoded data)" value-name:"CERT-FILE.crt"`
 	ClientKey  *string `long:"client-key" description:"TLS client private key file (PEM encoded data)" value-name:"KEY-FILE.pem"`

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -39,3 +39,8 @@ namespace = "https://example.com"
 issuing_authority = "We at Example Company are responsible for publishing and maintaining Product Y."
 contact_details = "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."
 ```
+Details on authentication:
+
+There are two options to restrict the access to the upload:
+1. ``` password ``` Access is restricted with a password. 
+2. The client certificate is verified at first by NGINX against the configured certificates (via ```ssl_client_certificate```, see [Client-Certificate based authentication](./client-certificate-setup.md) ). The access can be restricted futher with ``` issuer ```. The option contains the CN of the issuing CA, that the uploader uses. A configured password is ignored in this case.

--- a/docs/csaf_uploader.md
+++ b/docs/csaf_uploader.md
@@ -14,7 +14,7 @@ Application Options:
                                             beside CSAF files.
   -s, --no-schema-check                     Do not check files against CSAF JSON schema locally.
   -k, --key=KEY-FILE                        OpenPGP key to sign the CSAF files
-  -p, --password=PASSWORD                   Authentication password for accessing the CSAF provider
+  -p, --password=PASSWORD                   Authentication password for accessing the CSAF provider (Password is only used, if no client cert is configured)
   -P, --passphrase=PASSPHRASE               Passphrase to unlock the OpenPGP key
       --client-cert=CERT-FILE.crt           TLS client certificate file (PEM encoded data)
       --client-key=KEY-FILE.pem             TLS client private key file (PEM encoded data)


### PR DESCRIPTION
It should be clarified that the ```password``` by the provider and ```-p, --password=PASSWORD  ```by the uploader is not used/ignored, if client certificates are used. According to the documentation I was expecting that both are used, but that's not the case. 