### PR TITLE
Only create/update index.txt, changes.csv when configured.

### DIFF
--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -36,8 +36,9 @@ type provider struct {
 	Name   string `toml:"name"`
 	Domain string `toml:"domain"`
 	// Rate gives the provider specific rate limiting (see overall Rate).
-	Rate     *float64 `toml:"rate"`
-	Insecure *bool    `toml:"insecure"`
+	Rate         *float64 `toml:"rate"`
+	Insecure     *bool    `toml:"insecure"`
+	WriteIndices *bool    `toml:"write_indices"`
 }
 
 type config struct {
@@ -50,6 +51,7 @@ type config struct {
 	// Rate gives the average upper limit of https operations per second.
 	Rate                *float64            `toml:"rate"`
 	Insecure            *bool               `toml:"insecure"`
+	WriteIndices        bool                `toml:"write_indices"`
 	Aggregator          csaf.AggregatorInfo `toml:"aggregator"`
 	Providers           []*provider         `toml:"providers"`
 	OpenPGPPrivateKey   string              `toml:"openpgp_private_key"`
@@ -73,6 +75,14 @@ type config struct {
 	keyMu  sync.Mutex
 	key    *crypto.Key
 	keyErr error
+}
+
+// writeIndices tells if we should write index.txt and changes.csv.
+func (p *provider) writeIndices(c *config) bool {
+	if p.WriteIndices != nil {
+		return *p.WriteIndices
+	}
+	return c.WriteIndices
 }
 
 // runAsMirror determines if the aggregator should run in mirror mode.

--- a/cmd/csaf_aggregator/indices.go
+++ b/cmd/csaf_aggregator/indices.go
@@ -220,11 +220,14 @@ func (w *worker) writeIndices() error {
 		if err := w.writeInterims(label, summaries); err != nil {
 			return err
 		}
-		if err := w.writeCSV(label, summaries); err != nil {
-			return err
-		}
-		if err := w.writeIndex(label, summaries); err != nil {
-			return err
+		// Only write index.txt and changes.csv if configured.
+		if w.provider.writeIndices(w.processor.cfg) {
+			if err := w.writeCSV(label, summaries); err != nil {
+				return err
+			}
+			if err := w.writeIndex(label, summaries); err != nil {
+				return err
+			}
 		}
 		if err := w.writeROLIE(label, summaries); err != nil {
 			return err

--- a/cmd/csaf_provider/actions.go
+++ b/cmd/csaf_provider/actions.go
@@ -322,11 +322,14 @@ func (c *controller) upload(r *http.Request) (interface{}, error) {
 				return err
 			}
 
-			if err := updateIndices(
-				folder, filepath.Join(year, newCSAF),
-				ex.CurrentReleaseDate,
-			); err != nil {
-				return err
+			// Only write index.txt and changes.csv if configured.
+			if c.cfg.WriteIndices {
+				if err := updateIndices(
+					folder, filepath.Join(year, newCSAF),
+					ex.CurrentReleaseDate,
+				); err != nil {
+					return err
+				}
 			}
 
 			// Take over publisher

--- a/cmd/csaf_provider/config.go
+++ b/cmd/csaf_provider/config.go
@@ -56,6 +56,8 @@ type config struct {
 	UploadLimit             *int64                       `toml:"upload_limit"`
 	Issuer                  *string                      `toml:"issuer"`
 	RemoteValidator         *csaf.RemoteValidatorOptions `toml:"remote_validator"`
+	WriteIndices            bool                         `toml:"write_indices"`
+	WriteSecurity           bool                         `toml:"write_security"`
 }
 
 func (pmdc *providerMetadataConfig) apply(pmd *csaf.ProviderMetadata) {

--- a/cmd/csaf_provider/create.go
+++ b/cmd/csaf_provider/create.go
@@ -41,7 +41,13 @@ func ensureFolders(c *config) error {
 		}
 	}
 
-	return setupSecurity(c, wellknown)
+	// Only write/modify security.txt if configured.
+	if c.WriteSecurity {
+		if err := setupSecurity(c, wellknown); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // createWellknown creates ".well-known" directory if not exist and returns nil.

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -78,6 +78,7 @@ web                   // directory to be served by the webserver
 domain                // base url where the contents will be reachable from outside
 rate                  // overall downloading limit per worker
 insecure              // do not check validity of TLS certificates
+write_indices         // write index.txt and changes.csv
 aggregator            // table with basic infos for the aggregator object
 providers             // array of tables, each entry to be mirrored or listed
 openpgp_private_key   // OpenPGP private key

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -100,6 +100,7 @@ name
 domain
 rate
 insecure
+write_indices
 ```
 
 #### Example config file

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -79,8 +79,6 @@ domain                // base url where the contents will be reachable from outs
 rate                  // overall downloading limit per worker
 insecure              // do not check validity of TLS certificates
 write_indices         // write index.txt and changes.csv
-aggregator            // table with basic infos for the aggregator object
-providers             // array of tables, each entry to be mirrored or listed
 openpgp_private_key   // OpenPGP private key
 openpgp_public_key    // OpenPGP public key
 passphrase            // passphrase of the OpenPGP key
@@ -89,6 +87,8 @@ interim_years         // limiting the years for which interim documents are sear
 verbose               // print more diagnostic output, e.g. https request
 allow_single_provider // debugging option
 remote_validator      // use remote validation checker
+aggregator            // table with basic infos for the aggregator object
+providers             // array of tables, each entry to be mirrored or listed
 ```
 
 Rates are specified as floats in HTTPS operations per second.

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -21,6 +21,8 @@ Following options are supported in the config file:
  - dynamic_provider_metadata: Take the publisher from the CSAF document. Default: `false`.
  - upload_limit: Set the upload limit size of a file in bytes. Default: `52428800` (aka 50 MiB).
  - issuer: The issuer of the CA, which if set, restricts the writing permission and the accessing to the web-interface to only the client certificates signed with this CA.
+ - write_indices: Write/update `index.txt` and `changes.csv`. Default: false
+ - write_security: Write `CSAF:` entry into `security.txt`: Default: false
  - tlps: Set the allowed TLP comming with the upload request (one or more of "csaf", "white", "amber", "green", "red").
    The "csaf" selection lets the provider takes the value from the CSAF document.
    These affects the list items in the web interface.

--- a/docs/examples/aggregator.toml
+++ b/docs/examples/aggregator.toml
@@ -5,6 +5,13 @@ web = "/var/csaf_aggregator/html"
 domain = "https://localhost:9443"
 rate = 10.0
 insecure = true
+#key =
+#passphrase =
+#write_indices = false
+
+# specification requires at least two providers (default),
+# to override for testing, enable:
+# allow_single_provider = true
 
 [aggregator]
   category = "aggregator"
@@ -24,11 +31,4 @@ insecure = true
   domain = "localhost"
 #  rate = 1.2
 #  insecure = true
-
-#key =
-#passphrase =
-
-# specification requires at least two providers (default),
-# to override for testing, enable:
-# allow_single_provider = true
-
+  write_indices = true


### PR DESCRIPTION
Solves #77 

Maybe TODO: Don't allow directory listing of folders containing advisories?