### PR TITLE
reporters.go update 

### DIFF
--- a/cmd/csaf_checker/reporters.go
+++ b/cmd/csaf_checker/reporters.go
@@ -109,7 +109,7 @@ func (r *providerMetadataReport) report(p *processor, domain *Domain) {
 func (r *securityReporter) report(p *processor, domain *Domain) {
 	req := r.requirement(domain)
 	if !p.badSecurity.used() {
-		req.message(InfoType, "No security.txt checked.")
+		req.message(InfoType, "Performed no in-dedepth test of security.txt.")
 		return
 	}
 	if len(p.badSecurity) == 0 {


### PR DESCRIPTION
Updates error message given to user if no in-depth check of security.txt was performed.