### PR TITLE
Provider list mirror

### DIFF
--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -36,9 +36,10 @@ type provider struct {
 	Name   string `toml:"name"`
 	Domain string `toml:"domain"`
 	// Rate gives the provider specific rate limiting (see overall Rate).
-	Rate         *float64 `toml:"rate"`
-	Insecure     *bool    `toml:"insecure"`
-	WriteIndices *bool    `toml:"write_indices"`
+	Rate                *float64                 `toml:"rate"`
+	Insecure            *bool                    `toml:"insecure"`
+	WriteIndices        *bool                    `toml:"write_indices"`
+	AggregatoryCategory *csaf.AggregatorCategory `toml:"category"`
 }
 
 type config struct {
@@ -83,6 +84,22 @@ func (p *provider) writeIndices(c *config) bool {
 		return *p.WriteIndices
 	}
 	return c.WriteIndices
+}
+
+func (p *provider) runAsMirror(c *config) bool {
+	if p.AggregatoryCategory != nil {
+		return *p.AggregatoryCategory == csaf.AggregatorAggregator
+	}
+	return c.runAsMirror()
+}
+
+func (c *config) hasMirror() bool {
+	for _, p := range c.Providers {
+		if p.AggregatoryCategory != nil && *p.AggregatoryCategory == csaf.AggregatorAggregator {
+			return true
+		}
+	}
+	return c.runAsMirror()
 }
 
 // runAsMirror determines if the aggregator should run in mirror mode.

--- a/cmd/csaf_aggregator/full.go
+++ b/cmd/csaf_aggregator/full.go
@@ -24,6 +24,7 @@ import (
 type fullJob struct {
 	provider           *provider
 	aggregatorProvider *csaf.AggregatorCSAFProvider
+	work               fullWorkFunc
 	err                error
 }
 
@@ -61,11 +62,7 @@ func (w *worker) setupProviderFull(provider *provider) error {
 type fullWorkFunc func(*worker) (*csaf.AggregatorCSAFProvider, error)
 
 // fullWork handles the treatment of providers concurrently.
-func (w *worker) fullWork(
-	wg *sync.WaitGroup,
-	doWork fullWorkFunc,
-	jobs <-chan *fullJob,
-) {
+func (w *worker) fullWork(wg *sync.WaitGroup, jobs <-chan *fullJob) {
 	defer wg.Done()
 
 	for j := range jobs {
@@ -73,17 +70,14 @@ func (w *worker) fullWork(
 			j.err = err
 			continue
 		}
-		j.aggregatorProvider, j.err = doWork(w)
+		j.aggregatorProvider, j.err = j.work(w)
 	}
 }
 
 // full performs the complete lister/download
 func (p *processor) full() error {
 
-	var doWork fullWorkFunc
-
-	if p.cfg.runAsMirror() {
-
+	if p.cfg.hasMirror() {
 		// check if we need to setup a remote validator
 		if p.cfg.RemoteValidatorOptions != nil {
 			validator, err := p.cfg.RemoteValidatorOptions.Open()
@@ -99,11 +93,7 @@ func (p *processor) full() error {
 			}()
 		}
 
-		doWork = (*worker).mirror
 		log.Println("Running in aggregator mode")
-	} else {
-		doWork = (*worker).lister
-		log.Println("Running in lister mode")
 	}
 
 	queue := make(chan *fullJob)
@@ -113,13 +103,23 @@ func (p *processor) full() error {
 	for i := 1; i <= p.cfg.Workers; i++ {
 		wg.Add(1)
 		w := newWorker(i, p)
-		go w.fullWork(&wg, doWork, queue)
+		//go w.fullWork(&wg, doWork, queue)
+		go w.fullWork(&wg, queue)
 	}
 
 	jobs := make([]fullJob, len(p.cfg.Providers))
 
-	for i, p := range p.cfg.Providers {
-		jobs[i] = fullJob{provider: p}
+	for i, provider := range p.cfg.Providers {
+		var work fullWorkFunc
+		if provider.runAsMirror(p.cfg) {
+			work = (*worker).mirror
+		} else {
+			work = (*worker).lister
+		}
+		jobs[i] = fullJob{
+			provider: provider,
+			work:     work,
+		}
 		queue <- &jobs[i]
 	}
 	close(queue)

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -135,7 +135,6 @@ insecure = true
   domain = "localhost"
 #  rate = 1.5
 #  insecure = true
-#  category = "aggregator"
 
 [[providers]]
   name = "local-dev-provider2"
@@ -143,5 +142,14 @@ insecure = true
 #  rate = 1.2
 #  insecure = true
   write_indices = true
+  category = "aggregator"
+  
+[[providers]]
+  name = "local-dev-provider3"
+  domain = "localhost"
+#  rate = 1.8
+#  insecure = true
+  write_indices = true
+  category = "lister"
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -101,6 +101,7 @@ domain
 rate
 insecure
 write_indices
+category
 ```
 
 #### Example config file
@@ -134,6 +135,7 @@ insecure = true
   domain = "localhost"
 #  rate = 1.5
 #  insecure = true
+#  category = "aggregator"
 
 [[providers]]
   name = "local-dev-provider2"

--- a/docs/examples/aggregator.toml
+++ b/docs/examples/aggregator.toml
@@ -32,3 +32,12 @@ insecure = true
 #  rate = 1.2
 #  insecure = true
   write_indices = true
+  category = "aggregator"
+  
+[[providers]]
+  name = "local-dev-provider3"
+  domain = "localhost"
+#  rate = 1.8
+#  insecure = true
+  write_indices = true
+  category = "lister"


### PR DESCRIPTION
Allows for every provider to be set to be an aggregator or lister.  Defaults to the aggregators category if not set. Updates docs to so two provider set their own category, while the third inherits it from the aggregator.