### PR TITLE
Moved direct loading of pmd from downloader to library.

### DIFF
--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -240,10 +240,11 @@ func (p *processor) domainChecks(domain string) []func(*processor, string) error
 	)
 
 	if !direct {
-		checks = append(checks, (*processor).checkWellknownMetadataReporter)
+		checks = append(checks,
+			(*processor).checkWellknownMetadataReporter,
+			(*processor).checkDNSPathReporter,
+		)
 	}
-
-	checks = append(checks, (*processor).checkDNSPathReporter)
 
 	return checks
 }

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -215,20 +215,42 @@ func (p *processor) run(reporters []reporter, domains []string) (*Report, error)
 	return &report, nil
 }
 
-func (p *processor) checkDomain(domain string) error {
+// domainChecks compiles a list of checks which should be performed
+// for a given domain.
+func (p *processor) domainChecks(domain string) []func(*processor, string) error {
 
-	// TODO: Implement me!
-	for _, check := range []func(*processor, string) error{
+	// If we have a direct domain url we dont need to
+	// perform certain checks.
+	direct := strings.HasPrefix(domain, "https://")
+
+	checks := []func(*processor, string) error{
 		(*processor).checkProviderMetadata,
 		(*processor).checkPGPKeys,
-		(*processor).checkSecurity,
+	}
+
+	if !direct {
+		checks = append(checks, (*processor).checkSecurity)
+	}
+
+	checks = append(checks,
 		(*processor).checkCSAFs,
 		(*processor).checkMissing,
 		(*processor).checkInvalid,
 		(*processor).checkListing,
-		(*processor).checkWellknownMetadataReporter,
-		(*processor).checkDNSPathReporter,
-	} {
+	)
+
+	if !direct {
+		checks = append(checks, (*processor).checkWellknownMetadataReporter)
+	}
+
+	checks = append(checks, (*processor).checkDNSPathReporter)
+
+	return checks
+}
+
+func (p *processor) checkDomain(domain string) error {
+
+	for _, check := range p.domainChecks(domain) {
 		if err := check(p, domain); err != nil && err != errContinue {
 			if err == errStop {
 				return nil

--- a/csaf/util.go
+++ b/csaf/util.go
@@ -118,6 +118,8 @@ func LoadProviderMetadatasFromSecurity(client util.Client, path string) []*Loade
 
 // LoadProviderMetadataForDomain loads a provider metadata for a given domain.
 // Returns nil if no provider metadata was found.
+// If the domain starts with https:// it only attemps to load
+// the data from that URL.
 // The logging can be use to track the errors happening while loading.
 func LoadProviderMetadataForDomain(
 	client util.Client,
@@ -131,22 +133,33 @@ func LoadProviderMetadataForDomain(
 		}
 	}
 
+	lg := func(result *LoadedProviderMetadata, url string) {
+		if result == nil {
+			logging("%s not found.", url)
+		} else {
+			for _, msg := range result.Messages {
+				logging(msg)
+			}
+		}
+	}
+
+	// check direct path
+	if strings.HasPrefix(domain, "https://") {
+		result := LoadProviderMetadataFromURL(client, domain)
+		lg(result, domain)
+		return result
+	}
+
 	// Valid provider metadata under well-known.
 	var wellknownGood *LoadedProviderMetadata
 
 	// First try well-know path
 	wellknownURL := "https://" + domain + "/.well-known/csaf/provider-metadata.json"
 	wellknownResult := LoadProviderMetadataFromURL(client, wellknownURL)
+	lg(wellknownResult, wellknownURL)
 
-	if wellknownResult == nil {
-		logging("%s not found.", wellknownURL)
-	} else if len(wellknownResult.Messages) > 0 {
-		// There are issues
-		for _, msg := range wellknownResult.Messages {
-			logging(msg)
-		}
-	} else {
-		// We have a candidate.
+	// We have a candidate.
+	if wellknownResult != nil {
 		wellknownGood = wellknownResult
 	}
 

--- a/csaf/util.go
+++ b/csaf/util.go
@@ -117,10 +117,10 @@ func LoadProviderMetadatasFromSecurity(client util.Client, path string) []*Loade
 }
 
 // LoadProviderMetadataForDomain loads a provider metadata for a given domain.
-// Returns nil if no provider metadata was found.
-// If the domain starts with https:// it only attemps to load
+// Returns nil if no provider metadata (PMD) was found.
+// If the domain starts with `https://` it only attemps to load
 // the data from that URL.
-// The logging can be use to track the errors happening while loading.
+// The logging can be used to track the errors happening while loading.
 func LoadProviderMetadataForDomain(
 	client util.Client,
 	domain string,
@@ -220,8 +220,7 @@ func LoadProviderMetadataForDomain(
 		return wellknownGood
 	}
 
-	// Last resort fall back to DNS.
-
+	// Last resort: fall back to DNS.
 	dnsURL := "https://csaf.data.security." + domain
 	dnsResult := LoadProviderMetadataFromURL(client, dnsURL)
 

--- a/docs/examples/aggregator.toml
+++ b/docs/examples/aggregator.toml
@@ -28,7 +28,7 @@ insecure = true
 
 [[providers]]
   name = "local-dev-provider2"
-  domain = "localhost"
+  domain = "https://localhost:8443/.well-known/csaf/provider-metadata.json"
 #  rate = 1.2
 #  insecure = true
   write_indices = true


### PR DESCRIPTION
The `csaf.LoadProviderMetadataForDomain` now attempts to load a provider meta data file directly if the URL starts with `https://`

Issue #231 