### PR TITLE
Quick ckeck

### DIFF
--- a/cmd/csaf_checker/main.go
+++ b/cmd/csaf_checker/main.go
@@ -34,7 +34,7 @@ type options struct {
 	Version    bool     `long:"version" description:"Display version of the binary"`
 	Verbose    bool     `long:"verbose" short:"v" description:"Verbose output"`
 	Rate       *float64 `long:"rate" short:"r" description:"The average upper limit of https operations per second"`
-	Years      *uint    `long:"years" short:"y" description:"The years to look back from now" value-name:"YEARS"`
+	Years      *uint    `long:"years" short:"y" description:"Number of years to look back from now" value-name:"YEARS"`
 }
 
 func errCheck(err error) {

--- a/cmd/csaf_checker/main.go
+++ b/cmd/csaf_checker/main.go
@@ -34,6 +34,7 @@ type options struct {
 	Version    bool     `long:"version" description:"Display version of the binary"`
 	Verbose    bool     `long:"verbose" short:"v" description:"Verbose output"`
 	Rate       *float64 `long:"rate" short:"r" description:"The average upper limit of https operations per second"`
+	Years      *uint    `long:"years" short:"y" description:"The years to look back from now" value-name:"YEARS"`
 }
 
 func errCheck(err error) {

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -371,15 +371,15 @@ func (p *processor) integrity(
 
 		if m := yearFromURL.FindStringSubmatch(u); m != nil {
 			year, _ := strconv.Atoi(m[1])
-			folderYear = &year
 			// Check if we are in checking time interval.
 			if p.ageAccept != nil && !p.ageAccept(
 				time.Date(
-					year+1, 1, 1, // Assume 1. jan of next year.
-					0, 0, 0, 0,
+					year, 12, 31, // Assume last day og year.
+					23, 59, 59, 0, // 23:59:59
 					time.UTC)) {
 				continue
 			}
+			folderYear = &year
 		}
 
 		res, err := client.Get(u)

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -755,6 +755,10 @@ func (p *processor) checkChanges(base string, mask whereType) error {
 			if err != nil {
 				return nil, nil, err
 			}
+			// Apply date range filtering.
+			if p.ageAccept != nil && !p.ageAccept(t) {
+				continue
+			}
 			times, files = append(times, t), append(files, csaf.PlainAdvisoryFile(r[1]))
 		}
 		return times, files, nil

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -594,6 +594,13 @@ func (p *processor) processROLIEFeed(feed string) error {
 
 	rfeed.Entries(func(entry *csaf.Entry) {
 
+		// Filter if we have date checking.
+		if p.ageAccept != nil {
+			if pub := time.Time(entry.Published); !pub.IsZero() && !p.ageAccept(pub) {
+				return
+			}
+		}
+
 		var url, sha256, sha512, sign string
 
 		for i := range entry.Link {

--- a/docs/csaf_checker.md
+++ b/docs/csaf_checker.md
@@ -3,7 +3,7 @@
 ### Usage
 
 ```
-  csaf_checker [OPTIONS]
+csaf_checker [OPTIONS]
 
 Application Options:
   -o, --output=REPORT-FILE       File name of the generated report
@@ -13,8 +13,8 @@ Application Options:
       --client-key=KEY-FILE      TLS client private key file (PEM encoded data)
       --version                  Display version of the binary
   -v, --verbose                  Verbose output
-  -r, --rate=                    The average upper limit of https operations
-                                 per second
+  -r, --rate=                    The average upper limit of https operations per second
+  -y, --years=YEARS              Number of years to look back from now
 
 Help Options:
   -h, --help                     Show this help message


### PR DESCRIPTION
Solves #222

The checker now has a `-y/--years=YEARS` flag to determine how far
back from now it should evaluate the advisories.

If the advisories are take from a ROLIE feed the `published` date is
consulted, in case of `changes.csv` the respective date column is
used. If the URL of an advisory is place in a year folder, the
advisories are assumed are at least from the 31 December of
that year. 
