### PR TITLE
Only report bad directories in listing check only once.

### DIFF
--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -873,8 +873,10 @@ func (p *processor) checkListing(string) error {
 
 	var unlisted []string
 
+	badDirs := map[string]struct{}{}
+
 	for f := range p.alreadyChecked {
-		found, err := pgs.listed(f, p)
+		found, err := pgs.listed(f, p, badDirs)
 		if err != nil && err != errContinue {
 			return err
 		}


### PR DESCRIPTION
When running the listing check in the checker inaccessible folders are listed multiple times.
This PR fixes this, 