### PR TITLE
Unify loading of client certs in checker and uploader.

### DIFF
--- a/cmd/csaf_checker/main.go
+++ b/cmd/csaf_checker/main.go
@@ -171,11 +171,6 @@ func main() {
 		return
 	}
 
-	if opts.ClientCert != nil && opts.ClientKey == nil || opts.ClientCert == nil && opts.ClientKey != nil {
-		log.Println("Both client-key and client-cert options must be set for the authentication.")
-		return
-	}
-
 	p := newProcessor(opts)
 
 	report, err := p.run(buildReporters(), domains)

--- a/cmd/csaf_checker/main.go
+++ b/cmd/csaf_checker/main.go
@@ -13,6 +13,7 @@ import (
 	"crypto/tls"
 	_ "embed" // Used for embedding.
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
@@ -51,7 +52,12 @@ func errCheck(err error) {
 
 func (o *options) prepare() error {
 	// Load client certs.
-	if o.ClientCert != nil && o.ClientKey != nil {
+	switch hasCert, hasKey := o.ClientCert != nil, o.ClientKey != nil; {
+
+	case hasCert && !hasKey || !hasCert && hasKey:
+		return errors.New("both client-key and client-cert options must be set for the authentication")
+
+	case hasCert:
 		cert, err := tls.LoadX509KeyPair(*o.ClientCert, *o.ClientKey)
 		if err != nil {
 			return err


### PR DESCRIPTION
Avoid dying hard when loading of the clients certs during creation of an HTTP client. Check the failure at program start like in the checker.

Furthermore use same error message.
