### PR TITLE
Improve DNS example and itest setup

### DIFF
--- a/docs/scripts/DNSConfigForItest.sh
+++ b/docs/scripts/DNSConfigForItest.sh
@@ -26,7 +26,7 @@ echo "
 
         server_name ${DNS_NAME}; # e.g. server_name csaf.data.security.domain.tld;
 
-        location / {
+        location = / {
                 try_files /.well-known/csaf/provider-metadata.json =404;
         }
 


### PR DESCRIPTION
 * Make nginx only try to map the root (URL /) request to the
   provider-metadata.json for DNSPath, otherwise /index.txt  and all other URLs
   will also serve that single file.