### PR TITLE
Fixes canonical url prefix not being quoted and an extra ' at line 67 in the provider_config.toml

### DIFF
--- a/docs/examples/provider_config.toml
+++ b/docs/examples/provider_config.toml
@@ -23,7 +23,7 @@
 # Set the beginning of the URL where contents are accessible from the internet.
 # If not set, the provider will read from the $SERVER_NAME variable.
 # The following shows an example of a manually set prefix:
-#canonical_url_prefix  = https://localhost
+#canonical_url_prefix  = "https://localhost"
 
 # Require users to use a password and a valid Client Certificate for write access.
 #certificate_and_password = false
@@ -64,7 +64,7 @@
 # (one or more of "csaf", "white", "amber", "green", "red").
 # The "csaf" entry lets the provider take the value from the CSAF document.
 # These affect the list items in the web interface.
-#tlps = ["csaf", "white", "amber", "green", "red"]`
+#tlps = ["csaf", "white", "amber", "green", "red"]
 
 # Make the provider create a ROLIE service document.
 #create_service_document = false


### PR DESCRIPTION
Fixes  https://github.com/csaf-poc/csaf_distribution/issues/291