### PR TITLE
Go119

### DIFF
--- a/cmd/csaf_aggregator/doc.go
+++ b/cmd/csaf_aggregator/doc.go
@@ -1,7 +1,0 @@
-// csaf_aggregator is an implementation of the role CSAF Aggregator of the
-// CSAF 2.0 specification
-// (https://docs.oasis-open.org/csaf/csaf/v2.0/csd02/csaf-v2.0-csd02.html)
-//
-// TODO: To be called periodically, e.g with cron
-
-package main

--- a/cmd/csaf_aggregator/interim.go
+++ b/cmd/csaf_aggregator/interim.go
@@ -78,7 +78,7 @@ func (w *worker) checkInterims(
 		data.Reset()
 		hasher := io.MultiWriter(s256, &data)
 
-		var doc interface{}
+		var doc any
 		if err := func() error {
 			defer res.Body.Close()
 			tee := io.TeeReader(res.Body, hasher)

--- a/cmd/csaf_aggregator/main.go
+++ b/cmd/csaf_aggregator/main.go
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: 2022 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
 // Software-Engineering: 2022 Intevation GmbH <https://intevation.de>
 
+// Package main implements the csaf_aggregator tool.
 package main
 
 import (

--- a/cmd/csaf_aggregator/mirror.go
+++ b/cmd/csaf_aggregator/mirror.go
@@ -430,7 +430,7 @@ func (w *worker) sign(data []byte) (string, error) {
 		sig.Data, constants.PGPSignatureHeader, "", "")
 }
 
-func (w *worker) extractCategories(label string, advisory interface{}) error {
+func (w *worker) extractCategories(label string, advisory any) error {
 
 	// use provider or global categories
 	var categories []string
@@ -499,7 +499,7 @@ func (w *worker) mirrorFiles(tlpLabel csaf.TLPLabel, files []csaf.AdvisoryFile) 
 			continue
 		}
 
-		var advisory interface{}
+		var advisory any
 
 		s256 := sha256.New()
 		s512 := sha512.New()

--- a/cmd/csaf_aggregator/processor.go
+++ b/cmd/csaf_aggregator/processor.go
@@ -42,7 +42,7 @@ type worker struct {
 
 	client           util.Client                // client per provider
 	provider         *provider                  // current provider
-	metadataProvider interface{}                // current metadata provider
+	metadataProvider any                        // current metadata provider
 	loc              string                     // URL of current provider-metadata.json
 	dir              string                     // Directory to store data to.
 	summaries        map[string][]summary       // the summaries of the advisories.
@@ -80,7 +80,7 @@ func (w *worker) createDir() (string, error) {
 func (w *worker) locateProviderMetadata(domain string) error {
 
 	lpmd := csaf.LoadProviderMetadataForDomain(
-		w.client, domain, func(format string, args ...interface{}) {
+		w.client, domain, func(format string, args ...any) {
 			log.Printf(
 				"Looking for provider-metadata.json of '"+domain+"': "+format+"\n", args...)
 		})

--- a/cmd/csaf_checker/main.go
+++ b/cmd/csaf_checker/main.go
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: 2022 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
 // Software-Engineering: 2022 Intevation GmbH <https://intevation.de>
 
+// Package main implements the csaf_checker tool.
 package main
 
 import (

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -49,7 +49,7 @@ type processor struct {
 	alreadyChecked map[string]whereType
 	pmdURL         string
 	pmd256         []byte
-	pmd            interface{}
+	pmd            any
 	keys           []*crypto.KeyRing
 
 	badIntegrities       topicMessages
@@ -112,22 +112,22 @@ func (wt whereType) String() string {
 }
 
 // add adds a message to this topic.
-func (m *topicMessages) add(typ MessageType, format string, args ...interface{}) {
+func (m *topicMessages) add(typ MessageType, format string, args ...any) {
 	*m = append(*m, Message{Type: typ, Text: fmt.Sprintf(format, args...)})
 }
 
 // error adds an error message to this topic.
-func (m *topicMessages) error(format string, args ...interface{}) {
+func (m *topicMessages) error(format string, args ...any) {
 	m.add(ErrorType, format, args...)
 }
 
 // warn adds a warning message to this topic.
-func (m *topicMessages) warn(format string, args ...interface{}) {
+func (m *topicMessages) warn(format string, args ...any) {
 	m.add(WarnType, format, args...)
 }
 
 // info adds an info message to this topic.
-func (m *topicMessages) info(format string, args ...interface{}) {
+func (m *topicMessages) info(format string, args ...any) {
 	m.add(InfoType, format, args...)
 }
 
@@ -378,7 +378,7 @@ func (p *processor) integrity(
 	files []csaf.AdvisoryFile,
 	base string,
 	mask whereType,
-	lg func(MessageType, string, ...interface{}),
+	lg func(MessageType, string, ...any),
 ) error {
 	b, err := url.Parse(base)
 	if err != nil {
@@ -440,7 +440,7 @@ func (p *processor) integrity(
 		data.Reset()
 		hasher := io.MultiWriter(s256, s512, &data)
 
-		var doc interface{}
+		var doc any
 
 		if err := func() error {
 			defer res.Body.Close()
@@ -592,7 +592,7 @@ func (p *processor) processROLIEFeed(feed string) error {
 		return errContinue
 	}
 
-	rfeed, rolieDoc, err := func() (*csaf.ROLIEFeed, interface{}, error) {
+	rfeed, rolieDoc, err := func() (*csaf.ROLIEFeed, any, error) {
 		defer res.Body.Close()
 		all, err := io.ReadAll(res.Body)
 		if err != nil {
@@ -602,7 +602,7 @@ func (p *processor) processROLIEFeed(feed string) error {
 		if err != nil {
 			return nil, nil, fmt.Errorf("%s: %v", feed, err)
 		}
-		var rolieDoc interface{}
+		var rolieDoc any
 		err = json.NewDecoder(bytes.NewReader(all)).Decode(&rolieDoc)
 		return rfeed, rolieDoc, err
 
@@ -899,7 +899,7 @@ func (p *processor) checkCSAFs(domain string) error {
 		return err
 	}
 
-	fs, hasRolie := rolie.([]interface{})
+	fs, hasRolie := rolie.([]any)
 	hasRolie = hasRolie && len(fs) > 0
 
 	if hasRolie {

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -88,7 +88,7 @@ func (d *downloader) httpClient() util.Client {
 func (d *downloader) download(domain string) error {
 
 	lpmd := csaf.LoadProviderMetadataForDomain(
-		d.httpClient(), domain, func(format string, args ...interface{}) {
+		d.httpClient(), domain, func(format string, args ...any) {
 			log.Printf(
 				"Looking for provider-metadata.json of '"+domain+"': "+format+"\n", args...)
 		})
@@ -122,7 +122,7 @@ func (d *downloader) download(domain string) error {
 
 func (d *downloader) loadOpenPGPKeys(
 	client util.Client,
-	doc interface{},
+	doc any,
 	base *url.URL,
 ) error {
 
@@ -284,7 +284,7 @@ func (d *downloader) downloadFiles(label csaf.TLPLabel, files []csaf.AdvisoryFil
 		// Download the advisory and hash it.
 		hasher := io.MultiWriter(writers...)
 
-		var doc interface{}
+		var doc any
 
 		if err := func() error {
 			defer resp.Body.Close()

--- a/cmd/csaf_downloader/main.go
+++ b/cmd/csaf_downloader/main.go
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: 2022 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
 // Software-Engineering: 2022 Intevation GmbH <https://intevation.de>
 
+// Package main implements the csaf_downloader tool.
 package main
 
 import (

--- a/cmd/csaf_provider/actions.go
+++ b/cmd/csaf_provider/actions.go
@@ -132,7 +132,7 @@ func (c *controller) tlpParam(r *http.Request) (tlp, error) {
 
 // create calls the "ensureFolders" functions to create the directories and files.
 // It returns a struct by success, otherwise an error.
-func (c *controller) create(*http.Request) (interface{}, error) {
+func (c *controller) create(*http.Request) (any, error) {
 	if err := ensureFolders(c.cfg); err != nil {
 		return nil, err
 	}
@@ -144,14 +144,14 @@ func (c *controller) create(*http.Request) (interface{}, error) {
 	}, nil
 }
 
-func (c *controller) upload(r *http.Request) (interface{}, error) {
+func (c *controller) upload(r *http.Request) (any, error) {
 
 	newCSAF, data, err := c.loadCSAF(r)
 	if err != nil {
 		return nil, err
 	}
 
-	var content interface{}
+	var content any
 	if err := json.Unmarshal(data, &content); err != nil {
 		return nil, err
 	}

--- a/cmd/csaf_provider/controller.go
+++ b/cmd/csaf_provider/controller.go
@@ -131,7 +131,7 @@ func (c *controller) auth(
 // render sets the headers for the response. It applies the given template "tmpl" to
 // the given object "arg" and writes the output to http.ResponseWriter.
 // It logs a warning in case of error.
-func (c *controller) render(rw http.ResponseWriter, tmpl string, arg interface{}) {
+func (c *controller) render(rw http.ResponseWriter, tmpl string, arg any) {
 	rw.Header().Set("Content-type", "text/html; charset=utf-8")
 	rw.Header().Set("X-Content-Type-Options", "nosniff")
 	if err := c.tmpl.ExecuteTemplate(rw, tmpl, arg); err != nil {
@@ -142,13 +142,13 @@ func (c *controller) render(rw http.ResponseWriter, tmpl string, arg interface{}
 // failed constructs the error messages by calling "asMultiError" and calls "render"
 // function to render the passed template and error object.
 func (c *controller) failed(rw http.ResponseWriter, tmpl string, err error) {
-	result := map[string]interface{}{"Error": asMultiError(err)}
+	result := map[string]any{"Error": asMultiError(err)}
 	c.render(rw, tmpl, result)
 }
 
 // index calls the "render" function and passes the "index.html" and c.cfg to it.
 func (c *controller) index(rw http.ResponseWriter, r *http.Request) {
-	c.render(rw, "index.html", map[string]interface{}{
+	c.render(rw, "index.html", map[string]any{
 		"Config": c.cfg,
 	})
 }
@@ -158,7 +158,7 @@ func (c *controller) index(rw http.ResponseWriter, r *http.Request) {
 // in case of no error occurred, otherwise calls the "failed" function and passes the given
 // template and the error from "fn".
 func (c *controller) web(
-	fn func(*http.Request) (interface{}, error),
+	fn func(*http.Request) (any, error),
 	tmpl string,
 ) func(http.ResponseWriter, *http.Request) {
 
@@ -173,7 +173,7 @@ func (c *controller) web(
 
 // writeJSON sets the header for the response and writes the JSON encoding of the given "content".
 // It logs out an error message in case of an error.
-func writeJSON(rw http.ResponseWriter, content interface{}, code int) {
+func writeJSON(rw http.ResponseWriter, content any, code int) {
 	rw.Header().Set("Content-type", "application/json; charset=utf-8")
 	rw.Header().Set("X-Content-Type-Options", "nosniff")
 	rw.WriteHeader(code)
@@ -182,7 +182,7 @@ func writeJSON(rw http.ResponseWriter, content interface{}, code int) {
 	}
 }
 
-func errorToContent(err error) interface{} {
+func errorToContent(err error) any {
 	return &struct {
 		Errors multiError `json:"errors"`
 	}{
@@ -191,7 +191,7 @@ func errorToContent(err error) interface{} {
 }
 
 func api(
-	fn func(*http.Request) (interface{}, error),
+	fn func(*http.Request) (any, error),
 ) func(http.ResponseWriter, *http.Request) {
 
 	return func(rw http.ResponseWriter, r *http.Request) {

--- a/cmd/csaf_provider/main.go
+++ b/cmd/csaf_provider/main.go
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: 2021 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
 // Software-Engineering: 2021 Intevation GmbH <https://intevation.de>
 
+// Package main implements the csaf_provider.
 package main
 
 import (

--- a/cmd/csaf_uploader/main.go
+++ b/cmd/csaf_uploader/main.go
@@ -216,7 +216,7 @@ func (p *processor) uploadRequest(filename string) (*http.Request, error) {
 	}
 
 	if !p.opts.NoSchemaCheck {
-		var doc interface{}
+		var doc any
 		if err := json.NewDecoder(bytes.NewReader(data)).Decode(&doc); err != nil {
 			return nil, err
 		}

--- a/csaf/advisories.go
+++ b/csaf/advisories.go
@@ -73,9 +73,9 @@ func (haf HashedAdvisoryFile) SignURL() string { return haf.name(3, ".asc") }
 type AdvisoryFileProcessor struct {
 	client util.Client
 	expr   *util.PathEval
-	doc    interface{}
+	doc    any
 	base   *url.URL
-	log    func(format string, args ...interface{})
+	log    func(format string, args ...any)
 }
 
 // NewAdvisoryFileProcessor constructs an filename extractor
@@ -83,9 +83,9 @@ type AdvisoryFileProcessor struct {
 func NewAdvisoryFileProcessor(
 	client util.Client,
 	expr *util.PathEval,
-	doc interface{},
+	doc any,
 	base *url.URL,
-	log func(format string, args ...interface{}),
+	log func(format string, args ...any),
 ) *AdvisoryFileProcessor {
 	return &AdvisoryFileProcessor{
 		client: client,
@@ -113,7 +113,7 @@ func (afp *AdvisoryFileProcessor) Process(
 ) error {
 	lg := afp.log
 	if lg == nil {
-		lg = func(format string, args ...interface{}) {
+		lg = func(format string, args ...any) {
 			log.Printf("AdvisoryFileProcessor.Process: "+format, args...)
 		}
 	}
@@ -126,7 +126,7 @@ func (afp *AdvisoryFileProcessor) Process(
 		return err
 	}
 
-	fs, hasRolie := rolie.([]interface{})
+	fs, hasRolie := rolie.([]any)
 	hasRolie = hasRolie && len(fs) > 0
 
 	if hasRolie {
@@ -190,7 +190,7 @@ func (afp *AdvisoryFileProcessor) Process(
 // prefixed by baseURL/.
 func (afp *AdvisoryFileProcessor) loadIndex(
 	baseURL string,
-	lg func(string, ...interface{}),
+	lg func(string, ...any),
 ) ([]AdvisoryFile, error) {
 
 	base, err := url.Parse(baseURL)

--- a/csaf/doc.go
+++ b/csaf/doc.go
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: MIT
 //
-// SPDX-FileCopyrightText: 2022 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
-// Software-Engineering: 2022 Intevation GmbH <https://intevation.de>
+// SPDX-FileCopyrightText: 2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2023 Intevation GmbH <https://intevation.de>
 
 // Package csaf contains the core data models used by the csaf distribution.
 package csaf

--- a/csaf/doc.go
+++ b/csaf/doc.go
@@ -1,0 +1,10 @@
+// This file is Free Software under the MIT License
+// without warranty, see README.md and LICENSES/MIT.txt for details.
+//
+// SPDX-License-Identifier: MIT
+//
+// SPDX-FileCopyrightText: 2022 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2022 Intevation GmbH <https://intevation.de>
+
+// Package csaf contains the core data models used by the csaf distribution.
+package csaf

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -51,8 +51,8 @@ type test struct {
 
 // outDocument is the document send to the remote validation service.
 type outDocument struct {
-	Tests    []test      `json:"tests"`
-	Document interface{} `json:"document"`
+	Tests    []test `json:"tests"`
+	Document any    `json:"document"`
 }
 
 // inDocument is the document recieved from the remote validation service.
@@ -70,7 +70,7 @@ type cache interface {
 
 // RemoteValidator validates an advisory document remotely.
 type RemoteValidator interface {
-	Validate(doc interface{}) (bool, error)
+	Validate(doc any) (bool, error)
 	Close() error
 }
 
@@ -94,7 +94,7 @@ type syncedRemoteValidator struct {
 }
 
 // Validate implements the validation part of the RemoteValidator interface.
-func (srv *syncedRemoteValidator) Validate(doc interface{}) (bool, error) {
+func (srv *syncedRemoteValidator) Validate(doc any) (bool, error) {
 	srv.Lock()
 	defer srv.Unlock()
 	return srv.RemoteValidator.Validate(doc)
@@ -204,7 +204,7 @@ func (v *remoteValidator) Close() error {
 }
 
 // key calculates the key for an advisory document and presets.
-func (v *remoteValidator) key(doc interface{}) ([]byte, error) {
+func (v *remoteValidator) key(doc any) ([]byte, error) {
 	h := sha256.New()
 	if err := json.NewEncoder(h).Encode(doc); err != nil {
 		return nil, err
@@ -218,7 +218,7 @@ func (v *remoteValidator) key(doc interface{}) ([]byte, error) {
 }
 
 // Validate executes a remote validation of an advisory.
-func (v *remoteValidator) Validate(doc interface{}) (bool, error) {
+func (v *remoteValidator) Validate(doc any) (bool, error) {
 
 	var key []byte
 

--- a/csaf/summary.go
+++ b/csaf/summary.go
@@ -41,7 +41,7 @@ type AdvisorySummary struct {
 // with the help of an expression evaluator expr.
 func NewAdvisorySummary(
 	pe *util.PathEval,
-	doc interface{},
+	doc any,
 ) (*AdvisorySummary, error) {
 
 	e := &AdvisorySummary{

--- a/csaf/util.go
+++ b/csaf/util.go
@@ -27,7 +27,7 @@ type LoadedProviderMetadata struct {
 	// URL is location where the document was found.
 	URL string
 	// Document is the de-serialized JSON document.
-	Document interface{}
+	Document any
 	// Hash is a SHA256 sum over the document.
 	Hash []byte
 	// Messages are the error message happened while loading.
@@ -41,14 +41,14 @@ func (lpm *LoadedProviderMetadata) Valid() bool {
 
 // defaultLogging generates a logging function if given is nil.
 func defaultLogging(
-	logging func(format string, args ...interface{}),
+	logging func(format string, args ...any),
 	prefix, suffix string,
-) func(format string, args ...interface{}) {
+) func(format string, args ...any) {
 
 	if logging != nil {
 		return logging
 	}
-	return func(format string, args ...interface{}) {
+	return func(format string, args ...any) {
 		log.Printf(prefix+format+suffix, args...)
 	}
 }
@@ -59,7 +59,7 @@ func LoadProviderMetadataFromURL(
 	client util.Client,
 	url string,
 	already map[string]*LoadedProviderMetadata,
-	logging func(format string, args ...interface{}),
+	logging func(format string, args ...any),
 ) *LoadedProviderMetadata {
 
 	logging = defaultLogging(logging, "LoadProviderMetadataFromURL: ", "\n")
@@ -85,7 +85,7 @@ func LoadProviderMetadataFromURL(
 
 	tee := io.TeeReader(res.Body, hash)
 
-	var doc interface{}
+	var doc any
 
 	err = json.NewDecoder(tee).Decode(&doc)
 	// Before checking the err lets check if we had the same
@@ -143,7 +143,7 @@ func LoadProviderMetadatasFromSecurity(
 	client util.Client,
 	path string,
 	already map[string]*LoadedProviderMetadata,
-	logging func(format string, args ...interface{}),
+	logging func(format string, args ...any),
 ) []*LoadedProviderMetadata {
 
 	logging = defaultLogging(logging, "LoadProviderMetadataFromSecurity: ", "\n")
@@ -191,7 +191,7 @@ func LoadProviderMetadatasFromSecurity(
 func LoadProviderMetadataForDomain(
 	client util.Client,
 	domain string,
-	logging func(format string, args ...interface{}),
+	logging func(format string, args ...any),
 ) *LoadedProviderMetadata {
 
 	logging = defaultLogging(logging, "LoadProviderMetadataForDomain: ", "\n")

--- a/csaf/validation.go
+++ b/csaf/validation.go
@@ -95,7 +95,7 @@ func (cs *compiledSchema) compiler(sds []schemaData) {
 	}
 }
 
-func (cs *compiledSchema) validate(doc interface{}) ([]string, error) {
+func (cs *compiledSchema) validate(doc any) ([]string, error) {
 	cs.once.Do(cs.compile)
 
 	if cs.err != nil {
@@ -153,24 +153,24 @@ func (cs *compiledSchema) validate(doc interface{}) ([]string, error) {
 
 // ValidateCSAF validates the document doc against the JSON schema
 // of CSAF.
-func ValidateCSAF(doc interface{}) ([]string, error) {
+func ValidateCSAF(doc any) ([]string, error) {
 	return compiledCSAFSchema.validate(doc)
 }
 
 // ValidateProviderMetadata validates the document doc against the JSON schema
 // of provider metadata.
-func ValidateProviderMetadata(doc interface{}) ([]string, error) {
+func ValidateProviderMetadata(doc any) ([]string, error) {
 	return compiledProviderSchema.validate(doc)
 }
 
 // ValidateAggregator validates the document doc against the JSON schema
 // of aggregator.
-func ValidateAggregator(doc interface{}) ([]string, error) {
+func ValidateAggregator(doc any) ([]string, error) {
 	return compiledAggregatorSchema.validate(doc)
 }
 
 // ValidateROLIE validates the ROLIE feed against the JSON schema
 // of ROLIE
-func ValidateROLIE(doc interface{}) ([]string, error) {
+func ValidateROLIE(doc any) ([]string, error) {
 	return compiledRolieSchema.validate(doc)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/csaf-poc/csaf_distribution
 
-go 1.17
+go 1.19
 
 require (
 	github.com/BurntSushi/toml v1.1.0

--- a/util/doc.go
+++ b/util/doc.go
@@ -1,0 +1,10 @@
+// This file is Free Software under the MIT License
+// without warranty, see README.md and LICENSES/MIT.txt for details.
+//
+// SPDX-License-Identifier: MIT
+//
+// SPDX-FileCopyrightText: 2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2023 Intevation GmbH <https://intevation.de>
+
+// Package util implements several utilities functions and types.
+package util

--- a/util/json.go
+++ b/util/json.go
@@ -20,7 +20,7 @@ import (
 )
 
 // ReMarshalJSON transforms data from src to dst via JSON marshalling.
-func ReMarshalJSON(dst, src interface{}) error {
+func ReMarshalJSON(dst, src any) error {
 	intermediate, err := json.Marshal(src)
 	if err != nil {
 		return err
@@ -44,7 +44,7 @@ func NewPathEval() *PathEval {
 
 // Eval evalutes expression expr on document doc.
 // Returns the result of the expression.
-func (pe *PathEval) Eval(expr string, doc interface{}) (interface{}, error) {
+func (pe *PathEval) Eval(expr string, doc any) (any, error) {
 	if doc == nil {
 		return nil, errors.New("no document to extract data from")
 	}
@@ -65,21 +65,21 @@ type PathEvalMatcher struct {
 	// Expr is the expression to evaluate
 	Expr string
 	// Action is executed with the result of the match.
-	Action func(interface{}) error
+	Action func(any) error
 	// Optional expresses if the expression is optional.
 	Optional bool
 }
 
 // ReMarshalMatcher is an action to re-marshal the result to another type.
-func ReMarshalMatcher(dst interface{}) func(interface{}) error {
-	return func(src interface{}) error {
+func ReMarshalMatcher(dst any) func(any) error {
+	return func(src any) error {
 		return ReMarshalJSON(dst, src)
 	}
 }
 
 // BoolMatcher stores the matched result in a bool.
-func BoolMatcher(dst *bool) func(interface{}) error {
-	return func(x interface{}) error {
+func BoolMatcher(dst *bool) func(any) error {
+	return func(x any) error {
 		b, ok := x.(bool)
 		if !ok {
 			return errors.New("not a bool")
@@ -90,8 +90,8 @@ func BoolMatcher(dst *bool) func(interface{}) error {
 }
 
 // StringMatcher stores the matched result in a string.
-func StringMatcher(dst *string) func(interface{}) error {
-	return func(x interface{}) error {
+func StringMatcher(dst *string) func(any) error {
+	return func(x any) error {
 		s, ok := x.(string)
 		if !ok {
 			return errors.New("not a string")
@@ -102,8 +102,8 @@ func StringMatcher(dst *string) func(interface{}) error {
 }
 
 // TimeMatcher stores a time with a given format.
-func TimeMatcher(dst *time.Time, format string) func(interface{}) error {
-	return func(x interface{}) error {
+func TimeMatcher(dst *time.Time, format string) func(any) error {
+	return func(x any) error {
 		s, ok := x.(string)
 		if !ok {
 			return errors.New("not a string")
@@ -120,9 +120,9 @@ func TimeMatcher(dst *time.Time, format string) func(interface{}) error {
 // Extract extracts a value from a given document with a given expression/action.
 func (pe *PathEval) Extract(
 	expr string,
-	action func(interface{}) error,
+	action func(any) error,
 	optional bool,
-	doc interface{},
+	doc any,
 ) error {
 	optErr := func(err error) error {
 		if err == nil || optional {
@@ -138,7 +138,7 @@ func (pe *PathEval) Extract(
 }
 
 // Match matches a list of PathEvalMatcher pairs against a document.
-func (pe *PathEval) Match(matcher []PathEvalMatcher, doc interface{}) error {
+func (pe *PathEval) Match(matcher []PathEvalMatcher, doc any) error {
 	for _, m := range matcher {
 		if err := pe.Extract(m.Expr, m.Action, m.Optional, doc); err != nil {
 			return err
@@ -153,7 +153,7 @@ func (pe *PathEval) Match(matcher []PathEvalMatcher, doc interface{}) error {
 func (pe *PathEval) Strings(
 	exprs []string,
 	optional bool,
-	doc interface{},
+	doc any,
 ) ([]string, error) {
 	results := make([]string, 0, len(exprs))
 	var result string
@@ -169,8 +169,8 @@ func (pe *PathEval) Strings(
 
 // AsStrings transforms an []interface{string, string,... }
 // to a []string.
-func AsStrings(x interface{}) ([]string, bool) {
-	strs, ok := x.([]interface{})
+func AsStrings(x any) ([]string, bool) {
+	strs, ok := x.([]any)
 	if !ok {
 		return nil, false
 	}


### PR DESCRIPTION
* We demand Go 1.19 for a while now. Time to force it by setting this version in the `go.mod` file.
* Also use `any` instead of `interface{}` in source files.
* To make `revive` happy add package comments.