### PR TITLE
Extract more than one string from expr: category fields.

### DIFF
--- a/cmd/csaf_aggregator/mirror.go
+++ b/cmd/csaf_aggregator/mirror.go
@@ -451,18 +451,19 @@ func (w *worker) extractCategories(label string, advisory any) error {
 		w.categories[label] = cats
 	}
 
-	var result string
-	matcher := util.StringMatcher(&result)
-
 	const exprPrefix = "expr:"
 
 	for _, cat := range categories {
 		if strings.HasPrefix(cat, exprPrefix) {
 			expr := cat[len(exprPrefix):]
+			var results []string
+			matcher := util.StringTreeMatcher(&results)
 			if err := w.expr.Extract(expr, matcher, true, advisory); err != nil {
 				return err
 			}
-			cats[result] = true
+			for _, result := range results {
+				cats[result] = true
+			}
 		} else { // Normal
 			cats[cat] = true
 		}

--- a/cmd/csaf_provider/actions.go
+++ b/cmd/csaf_provider/actions.go
@@ -198,7 +198,7 @@ func (c *controller) upload(r *http.Request) (any, error) {
 		if dynamicCategories, err = pe.StringsFromTree(
 			catExprs, true, content); err != nil {
 			// XXX: Should we die here?
-			log.Printf("eval of dynamic catergory expressions failed: %v\n", err)
+			log.Printf("eval of dynamic category expressions failed: %v\n", err)
 		}
 	}
 

--- a/cmd/csaf_provider/actions.go
+++ b/cmd/csaf_provider/actions.go
@@ -194,11 +194,17 @@ func (c *controller) upload(r *http.Request) (any, error) {
 	// Check if we have to search for dynamic categories.
 	var dynamicCategories []string
 	if catExprs := c.cfg.DynamicCategories(); len(catExprs) > 0 {
-		var err error
-		if dynamicCategories, err = pe.StringsFromTree(
-			catExprs, true, content); err != nil {
-			// XXX: Should we die here?
-			log.Printf("eval of dynamic category expressions failed: %v\n", err)
+		matcher := util.StringTreeMatcher(&dynamicCategories)
+
+		for _, expr := range catExprs {
+			// Compile first to check that the expression is okay.
+			if _, err := pe.Compile(expr); err != nil {
+				log.Printf("Compiling category expression %q failed: %v\n",
+					expr, err)
+				continue
+			}
+			// Ignore errors here as they result from not matching.
+			pe.Extract(expr, matcher, true, content)
 		}
 	}
 

--- a/cmd/csaf_provider/actions.go
+++ b/cmd/csaf_provider/actions.go
@@ -195,9 +195,10 @@ func (c *controller) upload(r *http.Request) (any, error) {
 	var dynamicCategories []string
 	if catExprs := c.cfg.DynamicCategories(); len(catExprs) > 0 {
 		var err error
-		if dynamicCategories, err = pe.Strings(catExprs, true, content); err != nil {
+		if dynamicCategories, err = pe.StringsFromTree(
+			catExprs, true, content); err != nil {
 			// XXX: Should we die here?
-			log.Printf("eval of dynamic catecory expressions failed: %v\n", err)
+			log.Printf("eval of dynamic catergory expressions failed: %v\n", err)
 		}
 	}
 

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -113,9 +113,10 @@ The following example file documents all available configuration options:
 #   test succeeds the rules are applied recursively to
 #   collect all strings in the result.
 #   Suggested expressions are:
-#   - vendor, product family and product names:  "expr:$.product_tree..branches[?(@.category=='vendor' || @.category=='product_family' || @.category=='product_name')].name"
+#   - vendor, product family and product names:  "expr:$.product_tree..branches[?(@.category==\"vendor\" || @.category==\"product_family\" || @.category==\"product_name\")].name"
 #   - CVEs: "expr:$.vulnerabilities[*].cve"
 #   - CWEs: "expr:$.vulnerabilities[*].cwe.id"
+#  s implementation of JsonPath expressions does not support the use of single-quotes. Double quotes have to be quoted. 
 # Strings not starting with `expr:` are taken verbatim.
 # By default no category documents are created.
 # This example provides an overview over the syntax,

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -112,12 +112,6 @@ The following example file documents all available configuration options:
 #   If this test fails the expression fails. If the
 #   test succeeds the rules are applied recursively to
 #   collect all strings in the result.
-#   If the result of the expression is a string this string
-#   is used. If the result is an array each element of
-#   this array is tested if it is a string or an array.
-#   If this test fails the expression fails. If the
-#   test succeeds the rules are applied recursively to
-#   collect all strings in the result.
 #   Suggested expressions are:
 #   - vendor, product family and product names:  "expr:$.product_tree..branches[?(@.category=='vendor' || @.category=='product_family' || @.category=='product_name')].name"
 #   - CVEs: "expr:$.vulnerabilities[*].cve"

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -106,6 +106,12 @@ The following example file documents all available configuration options:
 # If a list item starts with `expr:`
 #   the rest of the string is used as a JsonPath expression
 #   to extract a string from the incoming advisories.
+#   If the result of the expression is a string this string
+#   is used. If the result is an array each element of
+#   this array is tested if it is a string or an array.
+#   If this test fails the expression fails. If the
+#   test succeeds the rules are applied recursively to
+#   collect all strings in the result.
 # Strings not starting with `expr:` are taken verbatim.
 # By default no category documents are created.
 # This example provides an overview over the syntax,

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -112,6 +112,16 @@ The following example file documents all available configuration options:
 #   If this test fails the expression fails. If the
 #   test succeeds the rules are applied recursively to
 #   collect all strings in the result.
+#   If the result of the expression is a string this string
+#   is used. If the result is an array each element of
+#   this array is tested if it is a string or an array.
+#   If this test fails the expression fails. If the
+#   test succeeds the rules are applied recursively to
+#   collect all strings in the result.
+#   Suggested expressions are:
+#   - vendor, product family and product names:  "expr:$.product_tree..branches[?(@.category=='vendor' || @.category=='product_family' || @.category=='product_name')].name"
+#   - CVEs: "expr:$.vulnerabilities[*].cve"
+#   - CWEs: "expr:$.vulnerabilities[*].cwe.id"
 # Strings not starting with `expr:` are taken verbatim.
 # By default no category documents are created.
 # This example provides an overview over the syntax,

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -116,7 +116,8 @@ The following example file documents all available configuration options:
 #   - vendor, product family and product names:  "expr:$.product_tree..branches[?(@.category==\"vendor\" || @.category==\"product_family\" || @.category==\"product_name\")].name"
 #   - CVEs: "expr:$.vulnerabilities[*].cve"
 #   - CWEs: "expr:$.vulnerabilities[*].cwe.id"
-#  s implementation of JsonPath expressions does not support the use of single-quotes. Double quotes have to be quoted. 
+#   The used implementation to evaluate JSONPath expressions does
+#   not support the use of single-quotes. Double quotes have to be quoted. 
 # Strings not starting with `expr:` are taken verbatim.
 # By default no category documents are created.
 # This example provides an overview over the syntax,

--- a/util/json.go
+++ b/util/json.go
@@ -101,8 +101,8 @@ func StringMatcher(dst *string) func(any) error {
 	}
 }
 
-// StringTreeMatcher returns a matcher which addis strings from
-// strings and recursively from arrays of strings.
+// StringTreeMatcher returns a matcher which adds strings
+// to a slice and recursively strings from arrays of strings.
 func StringTreeMatcher(strings *[]string) func(any) error {
 	// Only add unique strings.
 	unique := func(s string) {
@@ -179,8 +179,8 @@ func (pe *PathEval) Match(matcher []PathEvalMatcher, doc any) error {
 }
 
 // StringsFromTree returns strings from the given exprs.
-//  1. If a expression results a string this string is used.
-//  2. if a expression results in an array the elements
+//  1. If an expression results in a string this string is used.
+//  2. if an expression results in an array the elements
 //     of this array are recursively treated with 1. and 2.
 func (pe *PathEval) StringsFromTree(
 	exprs []string,

--- a/util/json.go
+++ b/util/json.go
@@ -101,8 +101,8 @@ func StringMatcher(dst *string) func(any) error {
 	}
 }
 
-// StringTreeMatcher returns a matcher which add strings from
-// stringss and recursively from arrays from strings.
+// StringTreeMatcher returns a matcher which addis strings from
+// strings and recursively from arrays of strings.
 func StringTreeMatcher(strings *[]string) func(any) error {
 	// Only add unique strings.
 	unique := func(s string) {

--- a/util/json.go
+++ b/util/json.go
@@ -42,6 +42,20 @@ func NewPathEval() *PathEval {
 	}
 }
 
+// Compile compiles an expression and stores it in the
+// internal cache on success.
+func (pe *PathEval) Compile(expr string) (gval.Evaluable, error) {
+	if eval := pe.exprs[expr]; eval != nil {
+		return eval, nil
+	}
+	eval, err := pe.builder.NewEvaluable(expr)
+	if err != nil {
+		return nil, err
+	}
+	pe.exprs[expr] = eval
+	return eval, nil
+}
+
 // Eval evalutes expression expr on document doc.
 // Returns the result of the expression.
 func (pe *PathEval) Eval(expr string, doc any) (any, error) {
@@ -176,25 +190,6 @@ func (pe *PathEval) Match(matcher []PathEvalMatcher, doc any) error {
 		}
 	}
 	return nil
-}
-
-// StringsFromTree returns strings from the given exprs.
-//  1. If an expression results in a string this string is used.
-//  2. if an expression results in an array the elements
-//     of this array are recursively treated with 1. and 2.
-func (pe *PathEval) StringsFromTree(
-	exprs []string,
-	optional bool,
-	doc any,
-) ([]string, error) {
-	results := make([]string, 0, len(exprs))
-	matcher := StringTreeMatcher(&results)
-	for _, expr := range exprs {
-		if err := pe.Extract(expr, matcher, optional, doc); err != nil {
-			return nil, err
-		}
-	}
-	return results, nil
 }
 
 // Strings searches the given document for the given set of expressions


### PR DESCRIPTION
Solves #299 

The result of the `expr:` JSONPaths are now expected to
be strings, arrays of strings or arrays of .. arrays of strings.
The flattened result consists of unique values.