### PR TITLE
Add remote validator support to downloader

### DIFF
--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -39,12 +39,37 @@ type downloader struct {
 	directory string
 	keys      []*crypto.KeyRing
 	eval      *util.PathEval
+	validator csaf.RemoteValidator
 }
 
-func newDownloader(opts *options) *downloader {
+func newDownloader(opts *options) (*downloader, error) {
+
+	var validator csaf.RemoteValidator
+
+	if opts.RemoteValidator != "" {
+		validatorOptions := csaf.RemoteValidatorOptions{
+			URL:     opts.RemoteValidator,
+			Presets: opts.RemoteValidatorPresets,
+			Cache:   opts.RemoteValidatorCache,
+		}
+		var err error
+		if validator, err = validatorOptions.Open(); err != nil {
+			return nil, fmt.Errorf(
+				"preparing remote validator failed: %w", err)
+		}
+	}
+
 	return &downloader{
-		opts: opts,
-		eval: util.NewPathEval(),
+		opts:      opts,
+		eval:      util.NewPathEval(),
+		validator: validator,
+	}, nil
+}
+
+func (d *downloader) close() {
+	if d.validator != nil {
+		d.validator.Close()
+		d.validator = nil
 	}
 }
 
@@ -328,6 +353,19 @@ func (d *downloader) downloadFiles(label csaf.TLPLabel, files []csaf.AdvisoryFil
 		if errors, err := csaf.ValidateCSAF(doc); err != nil || len(errors) > 0 {
 			d.logValidationIssues(file.URL(), errors, err)
 			continue
+		}
+
+		// Validate against remote validator
+		if d.validator != nil {
+			ok, err := d.validator.Validate(doc)
+			if err != nil {
+				return fmt.Errorf(
+					"calling remote validator on %q failed: %w",
+					file.URL(), err)
+			}
+			if !ok {
+				log.Printf("Remote validation of %q failed\n", file.URL())
+			}
 		}
 
 		if err := d.eval.Extract(`$.document.tracking.initial_release_date`, dateExtract, false, doc); err != nil {

--- a/cmd/csaf_downloader/main.go
+++ b/cmd/csaf_downloader/main.go
@@ -27,7 +27,7 @@ type options struct {
 
 	RemoteValidator        string   `long:"validator" description:"URL to validate documents remotely" value-name:"URL"`
 	RemoteValidatorCache   string   `long:"validatorcache" description:"FILE to cache remote validations" value-name:"FILE"`
-	RemoteValidatorPresets []string `long:"validatorpreset" description:"One or more presets to validate remotely"`
+	RemoteValidatorPresets []string `long:"validatorpreset" description:"One or more presets to validate remotely" default:"mandatory"`
 }
 
 func errCheck(err error) {

--- a/cmd/csaf_downloader/main.go
+++ b/cmd/csaf_downloader/main.go
@@ -19,11 +19,15 @@ import (
 )
 
 type options struct {
-	Directory *string  `short:"d" long:"directory" description:"Directory to store the downloaded files in"`
+	Directory *string  `short:"d" long:"directory" description:"DIRectory to store the downloaded files in" value-name:"DIR"`
 	Insecure  bool     `long:"insecure" description:"Do not check TLS certificates from provider"`
 	Version   bool     `long:"version" description:"Display version of the binary"`
 	Verbose   bool     `long:"verbose" short:"v" description:"Verbose output"`
 	Rate      *float64 `long:"rate" short:"r" description:"The average upper limit of https operations per second"`
+
+	RemoteValidator        string   `long:"validator" description:"URL to validate documents remotely" value-name:"URL"`
+	RemoteValidatorCache   string   `long:"validatorcache" description:"FILE to cache remote validations" value-name:"FILE"`
+	RemoteValidatorPresets []string `long:"validatorpreset" description:"One or more presets to validate remotely"`
 }
 
 func errCheck(err error) {
@@ -33,6 +37,15 @@ func errCheck(err error) {
 		}
 		log.Fatalf("error: %v\n", err)
 	}
+}
+
+func run(opts *options, domains []string) error {
+	d, err := newDownloader(opts)
+	if err != nil {
+		return err
+	}
+	defer d.close()
+	return d.run(domains)
 }
 
 func main() {
@@ -54,7 +67,5 @@ func main() {
 		return
 	}
 
-	d := newDownloader(opts)
-
-	errCheck(d.run(domains))
+	errCheck(run(opts, domains))
 }

--- a/docs/csaf_downloader.md
+++ b/docs/csaf_downloader.md
@@ -8,12 +8,15 @@ Usage:
   csaf_downloader [OPTIONS] domain...
 
 Application Options:
-  -d, --directory= Directory to store the downloaded files in
-      --insecure   Do not check TLS certificates from provider
-      --version    Display version of the binary
-  -v, --verbose    Verbose output
-  -r, --rate=      The average upper limit of https operations per second
+  -d, --directory=DIR          DIRectory to store the downloaded files in
+      --insecure               Do not check TLS certificates from provider
+      --version                Display version of the binary
+  -v, --verbose                Verbose output
+  -r, --rate=                  The average upper limit of https operations per second
+      --validator=URL          URL to validate documents remotely
+      --validatorcache=FILE    FILE to cache remote validations
+      --validatorpreset=       One or more presets to validate remotely
 
 Help Options:
-  -h, --help       Show this help message
+  -h, --help                   Show this help message
 ```

--- a/docs/csaf_downloader.md
+++ b/docs/csaf_downloader.md
@@ -15,7 +15,7 @@ Application Options:
   -r, --rate=                  The average upper limit of https operations per second
       --validator=URL          URL to validate documents remotely
       --validatorcache=FILE    FILE to cache remote validations
-      --validatorpreset=       One or more presets to validate remotely
+      --validatorpreset=       One or more presets to validate remotely (default: mandatory)
 
 Help Options:
   -h, --help                   Show this help message


### PR DESCRIPTION
This PR adds support for remote validation in `csaf_downloader`.

This partly resolves #300 