### PR TITLE
Improve setup script für Ubuntu systems

### DIFF
--- a/docs/scripts/prepareUbuntuInstanceForITests.sh
+++ b/docs/scripts/prepareUbuntuInstanceForITests.sh
@@ -11,4 +11,5 @@ apt install -y make bash sed tar git nginx fcgiwrap gnutls-bin
 # Install Go from binary distribution
 latest_go="$(curl https://go.dev/VERSION\?m=text).linux-amd64.tar.gz"
 curl -O https://dl.google.com/go/$latest_go
+rm -rf /usr/local/go # be sure that we do not have an old installation
 tar -C /usr/local -xzf $latest_go


### PR DESCRIPTION
  * Make sure that we do not have an old go installation around, because otherwise it maybe broken by untarring the newer one. As documented on https://go.dev/doc/install .