### PR TITLE
Improves aggregator docs

### DIFF
--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -85,7 +85,7 @@ type config struct {
 	// ServiceDocument incidates if we should create a service.json document.
 	ServiceDocument bool `toml:"create_service_document"`
 
-	// UpdateInterval is used for publishers a the mandatory field
+	// UpdateInterval is used for publishers as the mandatory field
 	// 'update_interval'.
 	UpdateInterval *string
 

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -117,7 +117,7 @@ to the resulting `aggregator.json`.
 Each publisher must announce an `update_interval` there.
 This can be configured for each entry, by the config option with the same name.
 If not given it is taken from the configured default
-and otherwise the internal default is "on best effort".
+Otherwise, the internal default "on best effort" is used.
 
 #### Example config file
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/examples/aggregator.toml) -->

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -111,11 +111,12 @@ in a `aggregator.category == "aggregator"` instance,
 set `category` to `lister` in the entry.
 Otherwise it is recommended to not set `category` for entries.
 
-If a provider's domain starts with https:// its considered a publisher.
-These publishers are added to the csaf_publishers list instead of the csaf_providers list which was used before.
-
-The mandatory value of update_interval can be configured for each publisher (provider) individually. If not given it falls back
-to the global update_interval. If this is not given either the default is "on best effort".
+If a provider's domain starts with `https://` its considered a publisher.
+These publishers are added to the `csaf_publishers` list.
+Each publisher must announce an `update_interval`.
+This can be configured for each entry.
+If not given it is taken from the global `update_interval`
+and otherwise the default is "on best effort".
 
 #### Example config file
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/examples/aggregator.toml) -->
@@ -179,4 +180,4 @@ insecure = true
 
 In case you want to provide CSAF advisories from others
 that only qualify as CSAF publishers, see
-[how to use the `csaf_aggregator` for it](proxy-provider-for-aggregator.md).
+[how to use the `csaf_aggregator` as "CSAF proxy provider"](proxy-provider-for-aggregator.md).

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -111,12 +111,13 @@ in a `aggregator.category == "aggregator"` instance,
 set `category` to `lister` in the entry.
 Otherwise it is recommended to not set `category` for entries.
 
-If a provider's domain starts with `https://` its considered a publisher.
-These publishers are added to the `csaf_publishers` list.
-Each publisher must announce an `update_interval`.
-This can be configured for each entry.
-If not given it is taken from the global `update_interval`
-and otherwise the default is "on best effort".
+If a provider's domain starts with `https://` it is considered a publisher.
+These publishers are added to the `csaf_publishers` list, written
+to the resulting `aggregator.json`.
+Each publisher must announce an `update_interval` there.
+This can be configured for each entry, by the config option with the same name.
+If not given it is taken from the configured default
+and otherwise the internal default is "on best effort".
 
 #### Example config file
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/examples/aggregator.toml) -->

--- a/docs/proxy-provider-for-aggregator.md
+++ b/docs/proxy-provider-for-aggregator.md
@@ -5,7 +5,7 @@ calls it a *CSAF publisher*.
 
 After manually downloading the advisories from such a publisher,
 the tools here can be used to offer the CSAF files for automated downloading
-as *CSAF aggregator*. (The construct is called *CSAF proxy provider*.)
+as *CSAF aggregator*. (The construct is called *CSAF proxy provider*. See [Section 7.2.5](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html#725-role-csaf-aggregator) for more details.)
 
 There are three necessary steps, easiest is to use
 one single virtual maschine (or container) per internal provider.

--- a/docs/proxy-provider-for-aggregator.md
+++ b/docs/proxy-provider-for-aggregator.md
@@ -5,7 +5,7 @@ calls it a *CSAF publisher*.
 
 After manually downloading the advisories from such a publisher,
 the tools here can be used to offer the CSAF files for automated downloading
-as *CSAF aggregator*.
+as *CSAF aggregator*. (The construct is called *CSAF proxy provider*.)
 
 There are three necessary steps, easiest is to use
 one single virtual maschine (or container) per internal provider.
@@ -48,7 +48,7 @@ the path via the variable, normally set in `/etc/nginx/fcgiwrap.conf`:
 (Careful: setting the variable a second time will transfer both values to
 fcgiwrap via an array. It is not guaranteed that the last value will be
 used. So if you are thinking about setting this variable dynamically,
-you need to make sure only once.)
+you need to make sure that is set only once.)
 
 For example you can clone the files
 ```bash
@@ -57,9 +57,8 @@ sudo vim /etc/nginx/fcgiwrap-p1.conf
 sudo cp /etc/nginx/sites-available/default /etc/nginx/sites-available/internal-p1-cgi
 sudo ln -s /etc/nginx/sites-available/internal-p1-cgi  /etc/nginx/sites-enabled/
 sudo vim  /etc/nginx/sites-available/internal-p1-cgi
-
-and then set the right config and port like
 ```
+and then set the right config file and port like
 
 ```nginx
         include fcgiwrap-p1.conf;


### PR DESCRIPTION
     * Add term "CSAF proxy provider", because it is mentioned now in
       https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html .
     * Improve formatting and phrasing.
     * Improve description of configuration of update_intervall.

improves #317 