### PR TITLE
Validator windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,11 +77,11 @@ dist: build_linux build_win
 	mkdir -p dist/$(DISTDIR)-windows-amd64/bin-windows-amd64
 	cp README.md dist/$(DISTDIR)-windows-amd64
 	cp bin-windows-amd64/csaf_uploader.exe bin-windows-amd64/csaf_validator.exe \
-	bin-windows-amd64/csaf_checker.exe bin-windows-amd64/csaf_downloader.exe \
-	dist/$(DISTDIR)-windows-amd64/bin-windows-amd64/
+	  bin-windows-amd64/csaf_checker.exe bin-windows-amd64/csaf_downloader.exe \
+	  dist/$(DISTDIR)-windows-amd64/bin-windows-amd64/
 	mkdir -p dist/$(DISTDIR)-windows-amd64/docs
 	cp docs/csaf_uploader.md docs/csaf_validator.md docs/csaf_checker.md \
-	docs/csaf_downloader.md dist/$(DISTDIR)-windows-amd64/docs
+	  docs/csaf_downloader.md dist/$(DISTDIR)-windows-amd64/docs
 	mkdir dist/$(DISTDIR)-gnulinux-amd64
 	cp -r README.md docs bin-linux-amd64 dist/$(DISTDIR)-gnulinux-amd64
 	cd dist/ ; zip -r $(DISTDIR)-windows-amd64.zip $(DISTDIR)-windows-amd64/

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ dist: build_linux build_win
 	mkdir -p dist/$(DISTDIR)-windows-amd64/bin-windows-amd64
 	cp README.md dist/$(DISTDIR)-windows-amd64
 	cp bin-windows-amd64/csaf_uploader.exe bin-windows-amd64/csaf_validator.exe \
-bin-windows-amd64/csaf_checker.exe bin-windows-amd64/csaf_downloader.exe \
-dist/$(DISTDIR)-windows-amd64/bin-windows-amd64/
+        bin-windows-amd64/csaf_checker.exe bin-windows-amd64/csaf_downloader.exe \
+        dist/$(DISTDIR)-windows-amd64/bin-windows-amd64/
 	mkdir -p dist/$(DISTDIR)-windows-amd64/docs
 	cp docs/csaf_uploader.md docs/csaf_validator.md docs/csaf_checker.md \
 docs/csaf_downloader.md dist/$(DISTDIR)-windows-amd64/docs

--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,12 @@ dist: build_linux build_win
 	mkdir -p dist
 	mkdir -p dist/$(DISTDIR)-windows-amd64/bin-windows-amd64
 	cp README.md dist/$(DISTDIR)-windows-amd64
-	cp bin-windows-amd64/csaf_uploader.exe bin-windows-amd64/csaf_validator.exe bin-windows-amd64/csaf_checker.exe bin-windows-amd64/csaf_downloader.exe dist/$(DISTDIR)-windows-amd64/bin-windows-amd64/
+	cp bin-windows-amd64/csaf_uploader.exe bin-windows-amd64/csaf_validator.exe \
+bin-windows-amd64/csaf_checker.exe bin-windows-amd64/csaf_downloader.exe \
+dist/$(DISTDIR)-windows-amd64/bin-windows-amd64/
 	mkdir -p dist/$(DISTDIR)-windows-amd64/docs
-	cp docs/csaf_uploader.md docs/csaf_validator.md docs/csaf_checker.md docs/csaf_downloader.md dist/$(DISTDIR)-windows-amd64/docs
+	cp docs/csaf_uploader.md docs/csaf_validator.md docs/csaf_checker.md \
+docs/csaf_downloader.md dist/$(DISTDIR)-windows-amd64/docs
 	mkdir dist/$(DISTDIR)-gnulinux-amd64
 	cp -r README.md docs bin-linux-amd64 dist/$(DISTDIR)-gnulinux-amd64
 	cd dist/ ; zip -r $(DISTDIR)-windows-amd64.zip $(DISTDIR)-windows-amd64/

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ dist: build_linux build_win
 	mkdir -p dist/$(DISTDIR)-windows-amd64/bin-windows-amd64
 	cp README.md dist/$(DISTDIR)-windows-amd64
 	cp bin-windows-amd64/csaf_uploader.exe bin-windows-amd64/csaf_validator.exe \
-        bin-windows-amd64/csaf_checker.exe bin-windows-amd64/csaf_downloader.exe \
-        dist/$(DISTDIR)-windows-amd64/bin-windows-amd64/
+	bin-windows-amd64/csaf_checker.exe bin-windows-amd64/csaf_downloader.exe \
+	dist/$(DISTDIR)-windows-amd64/bin-windows-amd64/
 	mkdir -p dist/$(DISTDIR)-windows-amd64/docs
 	cp docs/csaf_uploader.md docs/csaf_validator.md docs/csaf_checker.md \
 docs/csaf_downloader.md dist/$(DISTDIR)-windows-amd64/docs

--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,9 @@ dist: build_linux build_win
 	mkdir -p dist
 	mkdir -p dist/$(DISTDIR)-windows-amd64/bin-windows-amd64
 	cp README.md dist/$(DISTDIR)-windows-amd64
-	cp bin-windows-amd64/csaf_uploader.exe bin-windows-amd64/csaf_checker.exe bin-windows-amd64/csaf_downloader.exe dist/$(DISTDIR)-windows-amd64/bin-windows-amd64/
+	cp bin-windows-amd64/csaf_uploader.exe bin-windows-amd64/csaf_validator.exe bin-windows-amd64/csaf_checker.exe bin-windows-amd64/csaf_downloader.exe dist/$(DISTDIR)-windows-amd64/bin-windows-amd64/
 	mkdir -p dist/$(DISTDIR)-windows-amd64/docs
-	cp docs/csaf_uploader.md docs/csaf_checker.md docs/csaf_downloader.md dist/$(DISTDIR)-windows-amd64/docs
+	cp docs/csaf_uploader.md docs/csaf_validator.md docs/csaf_checker.md docs/csaf_downloader.md dist/$(DISTDIR)-windows-amd64/docs
 	mkdir dist/$(DISTDIR)-gnulinux-amd64
 	cp -r README.md docs bin-linux-amd64 dist/$(DISTDIR)-gnulinux-amd64
 	cd dist/ ; zip -r $(DISTDIR)-windows-amd64.zip $(DISTDIR)-windows-amd64/

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ dist: build_linux build_win
 	dist/$(DISTDIR)-windows-amd64/bin-windows-amd64/
 	mkdir -p dist/$(DISTDIR)-windows-amd64/docs
 	cp docs/csaf_uploader.md docs/csaf_validator.md docs/csaf_checker.md \
-docs/csaf_downloader.md dist/$(DISTDIR)-windows-amd64/docs
+	docs/csaf_downloader.md dist/$(DISTDIR)-windows-amd64/docs
 	mkdir dist/$(DISTDIR)-gnulinux-amd64
 	cp -r README.md docs bin-linux-amd64 dist/$(DISTDIR)-gnulinux-amd64
 	cd dist/ ; zip -r $(DISTDIR)-windows-amd64.zip $(DISTDIR)-windows-amd64/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ for GNU/Linux-Systems, e.g. Ubuntu LTS.
 They are likely to run on similar systems when build from sources.
 
 The windows binary package only includes
-`csaf_downloader`, `csaf_checker` and `csaf_uploader`.
+`csaf_downloader`, `csaf_validator`, `csaf_checker` and `csaf_uploader`.
 
 
 ### Prebuild binaries


### PR DESCRIPTION
Tested the validator on Windows 10 (successful).

Adds the Validator and its docs into the Windows dist. (Commit 1)

Adds linebreaks into the Makefile to shorten overly long lines. (Commit 2)

Solves https://github.com/csaf-poc/csaf_distribution/issues/326