### PR TITLE
Enforce `application/json` when uploading advisories to provider.

### DIFF
--- a/cmd/csaf_provider/actions.go
+++ b/cmd/csaf_provider/actions.go
@@ -42,6 +42,11 @@ func (c *controller) loadCSAF(r *http.Request) (string, []byte, error) {
 	}
 	defer file.Close()
 
+	// We reject everything which is not announced as JSON.
+	if handler.Header.Get("Content-Type") != "application/json" {
+		return "", nil, errors.New("expected content type 'application/json'")
+	}
+
 	if !util.ConfirmingFileName(handler.Filename) {
 		return "", nil, errors.New("given csaf filename is not confirming")
 	}

--- a/cmd/csaf_uploader/main.go
+++ b/cmd/csaf_uploader/main.go
@@ -209,9 +209,10 @@ func (p *processor) create() error {
 
 var escapeQuotes = strings.NewReplacer("\\", "\\\\", `"`, "\\\"").Replace
 
-// createFromFile creates an [io.Writer] like [mime/multipart.Writer.CreateFromFile].
+// createFormFile creates an [io.Writer] like [mime/multipart.Writer.CreateFromFile].
 // This version allows to set the mime type, too.
-func createFromFile(w *multipart.Writer, fieldname, filename, mimeType string) (io.Writer, error) {
+func createFormFile(w *multipart.Writer, fieldname, filename, mimeType string) (io.Writer, error) {
+	// Source: https://cs.opensource.google/go/go/+/refs/tags/go1.20:src/mime/multipart/writer.go;l=140
 	h := make(textproto.MIMEHeader)
 	h.Set("Content-Disposition",
 		fmt.Sprintf(`form-data; name="%s"; filename="%s"`,
@@ -249,7 +250,7 @@ func (p *processor) uploadRequest(filename string) (*http.Request, error) {
 
 	// As the csaf_provider only accepts uploads with mime type
 	// "application/json" we have to set this.
-	part, err := createFromFile(
+	part, err := createFormFile(
 		writer, "csaf", filepath.Base(filename), "application/json")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Resolves #148 