### PR TITLE
Add new requirements 1 and 2 to report

### DIFF
--- a/cmd/csaf_checker/main.go
+++ b/cmd/csaf_checker/main.go
@@ -144,6 +144,8 @@ func writeReport(report *Report, opts *options) error {
 // It returns an array of the reporter interface type.
 func buildReporters() []reporter {
 	return []reporter{
+		&validReporter{baseReporter{num: 1, description: "Valid CSAF documents"}},
+		&filenameReporter{baseReporter{num: 2, description: "Filename"}},
 		&tlsReporter{baseReporter{num: 3, description: "TLS"}},
 		&redirectsReporter{baseReporter{num: 6, description: "Redirects"}},
 		&providerMetadataReport{baseReporter{num: 7, description: "provider-metadata.json"}},

--- a/cmd/csaf_checker/report.go
+++ b/cmd/csaf_checker/report.go
@@ -73,6 +73,11 @@ func (r *Requirement) HasErrors() bool {
 	return false
 }
 
+// Append appends messages to requirement.
+func (r *Requirement) Append(msgs []Message) {
+	r.Messages = append(r.Messages, msgs...)
+}
+
 // HasErrors tells if this domain has errors.
 func (d *Domain) HasErrors() bool {
 	for _, r := range d.Requirements {

--- a/cmd/csaf_checker/reporters.go
+++ b/cmd/csaf_checker/reporters.go
@@ -19,6 +19,8 @@ type (
 		num         int
 		description string
 	}
+	validReporter             struct{ baseReporter }
+	filenameReporter          struct{ baseReporter }
 	tlsReporter               struct{ baseReporter }
 	redirectsReporter         struct{ baseReporter }
 	providerMetadataReport    struct{ baseReporter }
@@ -41,6 +43,29 @@ func (bc *baseReporter) requirement(domain *Domain) *Requirement {
 	}
 	domain.Requirements = append(domain.Requirements, req)
 	return req
+}
+
+// report reports if there where any invalid filenames,
+func (r *validReporter) report(p *processor, domain *Domain) {
+	req := r.requirement(domain)
+	if p.validator == nil {
+		req.message(InfoType, "No remote validator configured")
+	}
+	if !p.invalidAdvisories.used() {
+		req.message(InfoType, "No validations performed")
+	} else {
+		req.Append(p.invalidAdvisories)
+	}
+}
+
+// report reposrts if there where any bad filename.
+func (r *filenameReporter) report(p *processor, domain *Domain) {
+	req := r.requirement(domain)
+	if !p.badFilenames.used() {
+		req.message(InfoType, "No filenames checked for conformance")
+	} else {
+		req.Append(p.badFilenames)
+	}
 }
 
 // report tests if the URLs are HTTPS and sets the "message" field value
@@ -142,7 +167,7 @@ func (r *securityReporter) report(p *processor, domain *Domain) {
 	req.Messages = p.badSecurity
 }
 
-//report tests the availability of the "provider-metadata.json" under /.well-known/csaf/ directoy.
+// report tests the availability of the "provider-metadata.json" under /.well-known/csaf/ directoy.
 func (r *wellknownMetadataReporter) report(p *processor, domain *Domain) {
 	req := r.requirement(domain)
 	if !p.badWellknownMetadata.used() {

--- a/cmd/csaf_checker/reporters.go
+++ b/cmd/csaf_checker/reporters.go
@@ -60,7 +60,7 @@ func (r *validReporter) report(p *processor, domain *Domain) {
 	}
 }
 
-// report reposrts if there where any bad filename.
+// report reports if there where any bad filename.
 func (r *filenameReporter) report(p *processor, domain *Domain) {
 	req := r.requirement(domain)
 	if !p.badFilenames.used() {

--- a/cmd/csaf_checker/reporters.go
+++ b/cmd/csaf_checker/reporters.go
@@ -53,6 +53,8 @@ func (r *validReporter) report(p *processor, domain *Domain) {
 	}
 	if !p.invalidAdvisories.used() {
 		req.message(InfoType, "No validations performed")
+	} else if len(p.invalidAdvisories) == 0 {
+		req.message(InfoType, "All advisories validated fine.")
 	} else {
 		req.Append(p.invalidAdvisories)
 	}
@@ -63,6 +65,8 @@ func (r *filenameReporter) report(p *processor, domain *Domain) {
 	req := r.requirement(domain)
 	if !p.badFilenames.used() {
 		req.message(InfoType, "No filenames checked for conformance")
+	} else if len(p.badFilenames) == 0 {
+		req.message(InfoType, "All found filenames are confirming.")
 	} else {
 		req.Append(p.badFilenames)
 	}


### PR DESCRIPTION
Solves #301 
Solves #302 

This PR add two new sections to the report generated by the checker:

1. Valid CSAF document
2. Filename

If no remote validator is configured a respective note  is added to section 1.
Sections 1 and 2 lists the URLs which do not pass the respective tests.
It is noted if there were no tests performed. 