### PR TITLE
Iss319

### DIFF
--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -128,7 +128,7 @@ languages or values of the branch category within the product tree you
 can set providers categories values. This can be done using an array
 of strings taken literally or, by prepending "expr:", have it be read
 through JSONPath values. For a more detailed explanation,
-[refer to the provider config.](csaf_provider.md)
+[refer to the provider config](csaf_provider.md#provider-options).
 
 #### Example config file
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/examples/aggregator.toml) -->

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -124,10 +124,11 @@ a `service.json` will be written listing its ROLIE feed documents.
 If it is not set or set to false, then no `service.json` will be written.
 
 To further dissect CSAF-documents by criteria like document category,
-languages or values of the branch category within the Product Tree you
-can set a providers categories value as an array of either
-literal categories or, by prepending "expr:", have it be read
-through JSONPath values.
+languages or values of the branch category within the product tree you
+can set providers categories values. This can be done using an array
+of strings taken literally or, by prepending "expr:", have it be read
+through JSONPath values. For a more detailed explanation,
+[refer to the provider config.](csaf_provider.md)
 
 #### Example config file
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/examples/aggregator.toml) -->

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -125,8 +125,9 @@ If it is not set or set to false, then no `service.json` will be written.
 
 To further dissect CSAF-documents by criteria like document category,
 languages or values of the branch category within the Product Tree you
-can set a providers categories value. This consists of an array of either
-literal category values or, by prepending "expr:", JSONPath values.
+can set a providers categories value as an array of either
+literal categories or, by prepending "expr:", have it be read
+through JSONPath values.
 
 #### Example config file
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/examples/aggregator.toml) -->

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -125,7 +125,7 @@ If it is not set or set to false, then no `service.json` will be written.
 
 To offer an easy way of assorting CSAF documents by criteria like 
 document category, languages or values of the branch category within
-the product tree ROLIE category values can be configured. This can either
+the product tree, ROLIE category values can be configured. This can either
 be done using an array of strings taken literally or, by prepending `"expr:"`. 
 The latter is evaluated as JSONPath and the result will be added into the 
 categories document. For a more detailed explanation and examples,

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -123,11 +123,12 @@ If a provider's `create_service_document` option is set to true,
 a `service.json` will be written listing its ROLIE feed documents.
 If it is not set or set to false, then no `service.json` will be written.
 
-To further dissect CSAF-documents by criteria like document category,
-languages or values of the branch category within the product tree you
-can set providers categories values. This can be done using an array
-of strings taken literally or, by prepending "expr:", have it be read
-through JSONPath values. For a more detailed explanation,
+To offer an easy way of assorting CSAF documents by criteria like 
+document category, languages or values of the branch category within
+the product tree ROLIE category values can be configured. This can either
+be done using an array of strings taken literally or, by prepending `"expr:"`. 
+The latter is evaluated as JSONPath and the result will be added into the 
+categories document. For a more detailed explanation and examples,
 [refer to the provider config](csaf_provider.md#provider-options).
 
 #### Example config file

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -119,6 +119,15 @@ This can be configured for each entry, by the config option with the same name.
 If not given it is taken from the configured default
 Otherwise, the internal default "on best effort" is used.
 
+If a provider's `create_service_document` option is set to true,
+a `service.json` will be written listing its ROLIE feed documents.
+If it is not set or set to false, then no `service.json` will be written.
+
+To further dissect CSAF-documents by criteria like document category,
+languages or values of the branch category within the Product Tree you
+can set a providers categories value. This consists of an array of either
+literal category values or, by prepending "expr:", JSONPath values.
+
 #### Example config file
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/examples/aggregator.toml) -->
 <!-- The below code snippet is automatically added from ../docs/examples/aggregator.toml -->
@@ -170,7 +179,7 @@ insecure = true
 #  rate = 1.8
 #  insecure = true
   write_indices = true
-  # If aggregator.category == "aggreator", set for an entry that should
+  # If aggregator.category == "aggregator", set for an entry that should
   # be listed in addition:
   category = "lister"
 ```


### PR DESCRIPTION
What: 

Adds explanations of flags for the create_service_document and categories into aggregator.md

Why:

Solves https://github.com/csaf-poc/csaf_distribution/issues/319