### PR TITLE
Remote validator output

### DIFF
--- a/cmd/csaf_aggregator/mirror.go
+++ b/cmd/csaf_aggregator/mirror.go
@@ -544,7 +544,7 @@ func (w *worker) mirrorFiles(tlpLabel csaf.TLPLabel, files []csaf.AdvisoryFile) 
 				log.Printf("Calling remote validator failed: %s\n", err)
 				continue
 			}
-			if !valid {
+			if !valid.Valid {
 				log.Printf(
 					"CSAF file %s does not validate remotely.\n", file)
 				continue

--- a/cmd/csaf_aggregator/mirror.go
+++ b/cmd/csaf_aggregator/mirror.go
@@ -539,12 +539,12 @@ func (w *worker) mirrorFiles(tlpLabel csaf.TLPLabel, files []csaf.AdvisoryFile) 
 
 		// Check against remote validator.
 		if rmv := w.processor.remoteValidator; rmv != nil {
-			valid, err := rmv.Validate(advisory)
+			rvr, err := rmv.Validate(advisory)
 			if err != nil {
 				log.Printf("Calling remote validator failed: %s\n", err)
 				continue
 			}
-			if !valid.Valid {
+			if !rvr.Valid {
 				log.Printf(
 					"CSAF file %s does not validate remotely.\n", file)
 				continue

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -516,7 +516,7 @@ func (p *processor) integrity(
 		if p.validator != nil {
 			if ok, err := p.validator.Validate(doc); err != nil {
 				p.invalidAdvisories.error("Calling remote validator on %s failed: %v", u, err)
-			} else if !ok {
+			} else if !ok.Valid {
 				p.invalidAdvisories.error("Remote validation of %s failed.", u)
 			}
 		}

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -514,9 +514,9 @@ func (p *processor) integrity(
 
 		// Validate against remote validator.
 		if p.validator != nil {
-			if ok, err := p.validator.Validate(doc); err != nil {
+			if rvr, err := p.validator.Validate(doc); err != nil {
 				p.invalidAdvisories.error("Calling remote validator on %s failed: %v", u, err)
-			} else if !ok.Valid {
+			} else if !rvr.Valid {
 				p.invalidAdvisories.error("Remote validation of %s failed.", u)
 			}
 		}

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -376,7 +376,7 @@ func (d *downloader) downloadFiles(label csaf.TLPLabel, files []csaf.AdvisoryFil
 					"calling remote validator on %q failed: %w",
 					file.URL(), err)
 			}
-			if !ok {
+			if !ok.Valid {
 				log.Printf("Remote validation of %q failed\n", file.URL())
 			}
 		}

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -370,13 +370,13 @@ func (d *downloader) downloadFiles(label csaf.TLPLabel, files []csaf.AdvisoryFil
 
 		// Validate against remote validator
 		if d.validator != nil {
-			ok, err := d.validator.Validate(doc)
+			rvr, err := d.validator.Validate(doc)
 			if err != nil {
 				return fmt.Errorf(
 					"calling remote validator on %q failed: %w",
 					file.URL(), err)
 			}
-			if !ok.Valid {
+			if !rvr.Valid {
 				log.Printf("Remote validation of %q failed\n", file.URL())
 			}
 		}

--- a/cmd/csaf_provider/actions.go
+++ b/cmd/csaf_provider/actions.go
@@ -179,11 +179,11 @@ func (c *controller) upload(r *http.Request) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		valid, err := validator.Validate(content)
+		rvr, err := validator.Validate(content)
 		if err != nil {
 			return nil, err
 		}
-		if !valid.Valid {
+		if !rvr.Valid {
 			return nil, errors.New("does not validate against remote validator")
 		}
 	}

--- a/cmd/csaf_provider/actions.go
+++ b/cmd/csaf_provider/actions.go
@@ -183,7 +183,7 @@ func (c *controller) upload(r *http.Request) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		if !valid {
+		if !valid.Valid {
 			return nil, errors.New("does not validate against remote validator")
 		}
 	}

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -26,7 +26,7 @@ type options struct {
 	RemoteValidator        string   `long:"validator" description:"URL to validate documents remotely" value-name:"URL"`
 	RemoteValidatorCache   string   `long:"validatorcache" description:"FILE to cache remote validations" value-name:"FILE"`
 	RemoteValidatorPresets []string `long:"validatorpreset" description:"One or more presets to validate remotely" default:"mandatory"`
-	Output                 string   `short:"o" long:"output" description:"If a remote validator was used, display the results in JSON format"`
+	Output                 string   `short:"o" long:"output" description:"If a remote validator was used, display AMOUNT ('all', 'important' or 'short') results" value-name:"AMOUNT"`
 }
 
 // ShortTest is the result of the remote tests

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -88,6 +88,8 @@ func run(opts *options, files []string) error {
 		printResult = printShort
 	case "important":
 		printResult = printImportant
+	case "":
+		printResult = noPrint
 	default:
 		return fmt.Errorf("unknown output amount %q", opts.Output)
 	}
@@ -140,6 +142,8 @@ func run(opts *options, files []string) error {
 
 	return nil
 }
+
+func noPrint(*csaf.RemoteValidationResult) error { return nil }
 
 func printShort(rvr *csaf.RemoteValidationResult) error {
 	short := ShortTest{

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -26,7 +26,7 @@ type options struct {
 	RemoteValidator        string   `long:"validator" description:"URL to validate documents remotely" value-name:"URL"`
 	RemoteValidatorCache   string   `long:"validatorcache" description:"FILE to cache remote validations" value-name:"FILE"`
 	RemoteValidatorPresets []string `long:"validatorpreset" description:"One or more presets to validate remotely" default:"mandatory"`
-	Verbose                bool     `long:"verbose" description:"If a remote validator was used, display the results in JSON format"`
+	Output                 bool     `long:"output" description:"If a remote validator was used, display the results in JSON format"`
 }
 
 func main() {
@@ -60,7 +60,7 @@ func run(opts *options, files []string) error {
 			URL:     opts.RemoteValidator,
 			Presets: opts.RemoteValidatorPresets,
 			Cache:   opts.RemoteValidatorCache,
-			Verbose: opts.Verbose,
+			Output:  opts.Output,
 		}
 		var err error
 		if validator, err = validatorOptions.Open(); err != nil {

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -70,7 +70,7 @@ func run(opts *options, files []string) error {
 	}
 
 	// Select amount level of output for remote validation.
-	var printResult func(*csaf.RemoteValidationResult) error
+	var printResult func(*csaf.RemoteValidationResult)
 	switch opts.Output {
 	case "all":
 		printResult = printAll
@@ -116,10 +116,7 @@ func run(opts *options, files []string) error {
 				return fmt.Errorf("remote validation of %q failed: %w",
 					file, err)
 			}
-			if err := printResult(rvr); err != nil {
-				return fmt.Errorf("remote validation of %q failed: %w",
-					file, err)
-			}
+			printResult(rvr)
 			var passes string
 			if rvr.Valid {
 				passes = "passes"
@@ -134,7 +131,7 @@ func run(opts *options, files []string) error {
 }
 
 // noPrint suppresses the output of the validation result.
-func noPrint(*csaf.RemoteValidationResult) error { return nil }
+func noPrint(*csaf.RemoteValidationResult) {}
 
 // messageInstancePaths aggregates errors, warnings and infos by their
 // message.
@@ -192,7 +189,7 @@ func (mipl messageInstancePathsList) print(info string) {
 }
 
 // printShort outputs the validation result in an aggregated version.
-func printShort(rvr *csaf.RemoteValidationResult) error {
+func printShort(rvr *csaf.RemoteValidationResult) {
 
 	var errors, warnings, infos messageInstancePathsList
 
@@ -207,44 +204,41 @@ func printShort(rvr *csaf.RemoteValidationResult) error {
 	errors.print("errors:")
 	warnings.print("warnings:")
 	infos.print("infos:")
-
-	return nil
 }
 
 // printImportant displays only the test results which are really relevant.
-func printImportant(rvr *csaf.RemoteValidationResult) error {
-	return printRemoteValidationResult(rvr, func(rt *csaf.RemoteTest) bool {
+func printImportant(rvr *csaf.RemoteValidationResult) {
+	printRemoteValidationResult(rvr, func(rt *csaf.RemoteTest) bool {
 		return !rt.Valid ||
 			len(rt.Info) > 0 || len(rt.Error) > 0 || len(rt.Warning) > 0
 	})
 }
 
 // printAll displays all test results.
-func printAll(rvr *csaf.RemoteValidationResult) error {
-	return printRemoteValidationResult(rvr, func(*csaf.RemoteTest) bool {
+func printAll(rvr *csaf.RemoteValidationResult) {
+	printRemoteValidationResult(rvr, func(*csaf.RemoteTest) bool {
 		return true
 	})
 }
 
 // printInstanceAndMessages prints the message and the instance path of
 // a test result.
-func printInstanceAndMessages(info string, me []csaf.RemoteTestResult) error {
+func printInstanceAndMessages(info string, me []csaf.RemoteTestResult) {
 	if len(me) == 0 {
-		return nil
+		return
 	}
 	fmt.Printf("  %s\n", info)
 	for _, test := range me {
 		fmt.Printf("    instance path: %s\n", test.InstancePath)
 		fmt.Printf("    message: %s\n", test.Message)
 	}
-	return nil
 }
 
 // printRemoteValidationResult prints a filtered output of the remote validation result.
 func printRemoteValidationResult(
 	rvr *csaf.RemoteValidationResult,
 	accept func(*csaf.RemoteTest) bool,
-) error {
+) {
 
 	fmt.Printf("isValid: %t\n", rvr.Valid)
 	fmt.Println("tests:")
@@ -265,7 +259,6 @@ func printRemoteValidationResult(
 		printInstanceAndMessages("warnings:", test.Warning)
 		printInstanceAndMessages("infos:", test.Info)
 	}
-	return nil
 }
 
 func errCheck(err error) {

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -34,9 +34,9 @@ type options struct {
 // collapsed into minimal form.
 type ShortTest struct {
 	Valid   bool                     `json:"isValid"`
-        Error   []csaf.RemoteTestResults `json:"errors"`
-        Warning []csaf.RemoteTestResults `json:"warnings"`
-        Info    []csaf.RemoteTestResults `json:"infos"`
+	Error   []csaf.RemoteTestResults `json:"errors"`
+	Warning []csaf.RemoteTestResults `json:"warnings"`
+	Info    []csaf.RemoteTestResults `json:"infos"`
 }
 
 func main() {
@@ -157,7 +157,7 @@ func printDocuments(in csaf.RemoteValidationResult, output string) (bool, error)
 				}
 			}
 			if test.Error != nil {
-				for _, er  := range test.Error {
+				for _, er := range test.Error {
 					short.Error = append(short.Error, er)
 				}
 			}
@@ -182,7 +182,7 @@ func printRemoteValidationResult(in csaf.RemoteValidationResult) error {
 	if err != nil {
 		return fmt.Errorf("Error while displaying remote validator result.")
 	} else {
- 		fmt.Println(string(output))
+		fmt.Println(string(output))
 	}
 	return nil
 }

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -178,13 +178,61 @@ func printImportant(rvr *csaf.RemoteValidationResult) error {
 	return printRemoteValidationResult(&important)
 }
 
-func printRemoteValidationResult(in *csaf.RemoteValidationResult) error {
-	output, err := json.MarshalIndent(in, "", "    ")
-	if err != nil {
-		return fmt.Errorf("error while displaying remote validator result")
+func printInstanceAndMessages(me []csaf.RemoteTestResult) error{
+	for in, test := range me {
+		fmt.Println("      {")
+		fmt.Printf("        \"instancePath\": \"%s\",\n", test.InstancePath)
+		fmt.Printf("        \"message\": \"%s\"\n", test.Message)
+		fmt.Printf("      }")
+		if in < len(me)-1{
+			fmt.Println(",")
+		} else {
+			fmt.Println("")
+		}
 	}
-	_, err = fmt.Println(string(output))
-	return err
+	return nil
+}
+
+func printRemoteValidationResult(in *csaf.RemoteValidationResult) error {
+
+	fmt.Println("\"isValid\":", in.Valid)
+	if len(in.Tests) == 0 {
+		fmt.Println("\"tests\": []")
+		return nil
+	}
+	fmt.Println("\"tests\": [")
+	for i, test := range in.Tests {
+		fmt.Println("  {")
+		if len(test.Error) == 0 {
+			fmt.Println("    \"errors\":[],")
+		} else {
+			fmt.Println("    \"errors\": [")
+			printInstanceAndMessages(test.Error)
+			fmt.Println("    ],")
+		}
+		if len(test.Info) == 0 {
+			fmt.Println("    \"infos\":[],")
+		} else {
+			fmt.Println("    \"infos\": [")
+			printInstanceAndMessages(test.Info)
+			fmt.Println("    ],")
+		}
+		if len(test.Warning) == 0 {
+			fmt.Println("    \"warnings\":[],")
+		} else {
+			fmt.Println("    \"warnings\": [")
+			printInstanceAndMessages(test.Warning)
+			fmt.Println("    ],")
+		}
+		fmt.Printf("    \"isValid\": %t,\n", test.Valid)
+		fmt.Printf("    \"name\": \"%s\"\n", test.Name)
+		if i < len(in.Tests)-1 {
+			fmt.Println("  },")
+		}
+	}
+	fmt.Println("  }")
+	fmt.Println("]")
+	return nil
 }
 
 func errCheck(err error) {

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -26,6 +26,7 @@ type options struct {
 	RemoteValidator        string   `long:"validator" description:"URL to validate documents remotely" value-name:"URL"`
 	RemoteValidatorCache   string   `long:"validatorcache" description:"FILE to cache remote validations" value-name:"FILE"`
 	RemoteValidatorPresets []string `long:"validatorpreset" description:"One or more presets to validate remotely" default:"mandatory"`
+	Verbose                bool     `long:"verbose" description:"Display detailed results from the remote validator"`
 }
 
 func main() {
@@ -59,6 +60,7 @@ func run(opts *options, files []string) error {
 			URL:     opts.RemoteValidator,
 			Presets: opts.RemoteValidatorPresets,
 			Cache:   opts.RemoteValidatorCache,
+			Verbose: opts.Verbose,
 		}
 		var err error
 		if validator, err = validatorOptions.Open(); err != nil {

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -183,8 +183,8 @@ func printRemoteValidationResult(in *csaf.RemoteValidationResult) error {
 	if err != nil {
 		return fmt.Errorf("error while displaying remote validator result")
 	}
-	fmt.Println(string(output))
-	return nil
+	_, err = fmt.Println(string(output))
+	return err
 }
 
 func errCheck(err error) {

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -139,8 +139,9 @@ func printDocuments(in csaf.RemoteValidationResult, output string) (bool, error)
 	case "important":
 		var important csaf.RemoteValidationResult
 		important.Valid = in.Valid
+		important.Tests = []csaf.RemoteTest{}
 		for _, test := range in.Tests {
-			if test.Info != nil || test.Error != nil || test.Warning != nil {
+			if len(test.Info) > 0 || len(test.Error) > 0 || len(test.Warning) > 0 {
 				important.Tests = append(important.Tests, test)
 			}
 		}
@@ -150,18 +151,22 @@ func printDocuments(in csaf.RemoteValidationResult, output string) (bool, error)
 		}
 	case "short":
 		var short ShortTest
+		short.Valid = in.Valid
+		short.Info = []csaf.RemoteTestResults{}
+		short.Warning = []csaf.RemoteTestResults{}
+		short.Error = []csaf.RemoteTestResults{}
 		for _, test := range in.Tests {
-			if test.Info != nil {
+			if len(test.Info) > 0 {
 				for _, in := range test.Info {
 					short.Info = append(short.Info, in)
 				}
 			}
-			if test.Error != nil {
+			if len(test.Error) > 0 {
 				for _, er := range test.Error {
 					short.Error = append(short.Error, er)
 				}
 			}
-			if test.Warning != nil {
+			if len(test.Warning) > 0 {
 				for _, wa := range test.Warning {
 					short.Warning = append(short.Warning, wa)
 				}

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -153,7 +153,7 @@ func (mipl *messageInstancePathsList) addAll(rtrs []csaf.RemoteTestResult) {
 	}
 }
 
-// add adds a test result by avoiding duplicates.
+// add adds a test result unless it is a duplicate.
 func (mipl *messageInstancePathsList) add(rtr csaf.RemoteTestResult) {
 	for i := range *mipl {
 		m := &(*mipl)[i]

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -26,7 +26,7 @@ type options struct {
 	RemoteValidator        string   `long:"validator" description:"URL to validate documents remotely" value-name:"URL"`
 	RemoteValidatorCache   string   `long:"validatorcache" description:"FILE to cache remote validations" value-name:"FILE"`
 	RemoteValidatorPresets []string `long:"validatorpreset" description:"One or more presets to validate remotely" default:"mandatory"`
-	Output                 bool     `long:"output" description:"If a remote validator was used, display the results in JSON format"`
+	Output                 bool     `short:"o" long:"output" description:"If a remote validator was used, display the results in JSON format"`
 }
 
 func main() {

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -26,7 +26,7 @@ type options struct {
 	RemoteValidator        string   `long:"validator" description:"URL to validate documents remotely" value-name:"URL"`
 	RemoteValidatorCache   string   `long:"validatorcache" description:"FILE to cache remote validations" value-name:"FILE"`
 	RemoteValidatorPresets []string `long:"validatorpreset" description:"One or more presets to validate remotely" default:"mandatory"`
-	Verbose                bool     `long:"verbose" description:"Display detailed results from the remote validator"`
+	Verbose                bool     `long:"verbose" description:"If a remote validator was used, display the results in JSON format"`
 }
 
 func main() {

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -174,10 +174,9 @@ func printDocuments(in csaf.RemoteValidationResult, output string) (bool, error)
 		}
 		output, err := json.MarshalIndent(short, "", "    ")
 		if err != nil {
-			return false, fmt.Errorf("Error while displaying remote validator result.")
-		} else {
-			fmt.Println(string(output))
+			return false, fmt.Errorf("error while displaying remote validator result")
 		}
+		fmt.Println(string(output))
 	}
 	return in.Valid, nil
 }
@@ -185,10 +184,9 @@ func printDocuments(in csaf.RemoteValidationResult, output string) (bool, error)
 func printRemoteValidationResult(in csaf.RemoteValidationResult) error {
 	output, err := json.MarshalIndent(in, "", "    ")
 	if err != nil {
-		return fmt.Errorf("Error while displaying remote validator result.")
-	} else {
-		fmt.Println(string(output))
+		return fmt.Errorf("error while displaying remote validator result")
 	}
+	fmt.Println(string(output))
 	return nil
 }
 

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -133,21 +133,27 @@ func run(opts *options, files []string) error {
 	return nil
 }
 
+// noPrint suppresses the output of the validation result.
 func noPrint(*csaf.RemoteValidationResult) error { return nil }
 
+// messageInstancePaths aggregates errors, warnings and infos by their
+// message.
 type messageInstancePaths struct {
 	message string
 	paths   []string
 }
 
+// messageInstancePathsList is a list for errors, warnings or infos.
 type messageInstancePathsList []messageInstancePaths
 
+// addAll adds all errors, warnings or infos of a test.
 func (mipl *messageInstancePathsList) addAll(rtrs []csaf.RemoteTestResult) {
 	for _, rtr := range rtrs {
 		mipl.add(rtr)
 	}
 }
 
+// add adds a test result by avoiding duplicates.
 func (mipl *messageInstancePathsList) add(rtr csaf.RemoteTestResult) {
 	for i := range *mipl {
 		m := &(*mipl)[i]
@@ -169,6 +175,7 @@ func (mipl *messageInstancePathsList) add(rtr csaf.RemoteTestResult) {
 	})
 }
 
+// print prints the details of the list to stdout if there are any.
 func (mipl messageInstancePathsList) print(info string) {
 	if len(mipl) == 0 {
 		return
@@ -184,6 +191,7 @@ func (mipl messageInstancePathsList) print(info string) {
 	}
 }
 
+// printShort outputs the validation result in an aggregated version.
 func printShort(rvr *csaf.RemoteValidationResult) error {
 
 	var errors, warnings, infos messageInstancePathsList
@@ -203,18 +211,23 @@ func printShort(rvr *csaf.RemoteValidationResult) error {
 	return nil
 }
 
+// printImportant displays only the test results which are really relevant.
 func printImportant(rvr *csaf.RemoteValidationResult) error {
 	return printRemoteValidationResult(rvr, func(rt *csaf.RemoteTest) bool {
-		return len(rt.Info) > 0 || len(rt.Error) > 0 || len(rt.Warning) > 0
+		return !rt.Valid ||
+			len(rt.Info) > 0 || len(rt.Error) > 0 || len(rt.Warning) > 0
 	})
 }
 
+// printAll displays all test results.
 func printAll(rvr *csaf.RemoteValidationResult) error {
 	return printRemoteValidationResult(rvr, func(*csaf.RemoteTest) bool {
 		return true
 	})
 }
 
+// printInstanceAndMessages prints the message and the instance path of
+// a test result.
 func printInstanceAndMessages(info string, me []csaf.RemoteTestResult) error {
 	if len(me) == 0 {
 		return nil
@@ -227,6 +240,7 @@ func printInstanceAndMessages(info string, me []csaf.RemoteTestResult) error {
 	return nil
 }
 
+// printRemoteValidationResult prints a filtered output of the remote validation result.
 func printRemoteValidationResult(
 	rvr *csaf.RemoteValidationResult,
 	accept func(*csaf.RemoteTest) bool,

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -112,9 +112,9 @@ func SynchronizedRemoteValidator(validator RemoteValidator) RemoteValidator {
 
 // remoteValidator is an implementation of an RemoteValidator.
 type remoteValidator struct {
-	url     string
-	tests   []test
-	cache   cache
+	url    string
+	tests  []test
+	cache  cache
 	output bool
 }
 
@@ -220,10 +220,10 @@ func (rvo *RemoteValidatorOptions) Open() (RemoteValidator, error) {
 		return nil, err
 	}
 	return &remoteValidator{
-		url:     prepareURL(rvo.URL),
-		tests:   prepareTests(rvo.Presets),
-		cache:   cache,
-		output:  rvo.Output,
+		url:    prepareURL(rvo.URL),
+		tests:  prepareTests(rvo.Presets),
+		cache:  cache,
+		output: rvo.Output,
 	}, nil
 }
 

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -158,22 +158,19 @@ func prepareCache(config string) (cache, error) {
 	if err := db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucketIfNotExists(validationsBucket)
 		v := b.Get([]byte("version"))
-
 		// if version is wrong or nonexistent, delete old cache
-		if bytes.Equal(v, versionOfBucket) {
-			err := b.DeleteBucket(validationsBucket)
+		if !bytes.Equal(v, versionOfBucket) {
+			err := tx.DeleteBucket(validationsBucket)
 			if err != nil {
 				return err
 			}
-
 			// create new cache
-			c, err := tx.CreateBucket(validationsBucket)
+			b, err := tx.CreateBucket(validationsBucket)
 			if err != nil {
 				return err
 			}
-
 			// version it
-			err = c.Put([]byte("version"), versionOfBucket)
+			err = b.Put([]byte("version"), versionOfBucket)
 			if err != nil {
 				return err
 			}

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -42,7 +42,6 @@ type RemoteValidatorOptions struct {
 	URL     string   `json:"url" toml:"url"`
 	Presets []string `json:"presets" toml:"presets"`
 	Cache   string   `json:"cache" toml:"cache"`
-	Output  bool     `json:"output" toml:"output"`
 }
 
 type test struct {
@@ -59,27 +58,15 @@ type outDocument struct {
 // rtest is the result of the remote tests
 // recieved by the remote validation service.
 type rtest struct {
-	Error   []rerrors   `json:"errors"`
-	Info    []rinfos    `json:"infos"`
-	Warning []rwarnings `json:"warnings"`
-	Valid   bool        `json:"isValid"`
-	Name    string      `json:"name"`
+	Error   []remoteResults `json:"errors"`
+	Info    []remoteResults `json:"infos"`
+	Warning []remoteResults `json:"warnings"`
+	Valid   bool            `json:"isValid"`
+	Name    string          `json:"name"`
 }
 
-// Any warning given by a remote validator test.
-type rwarnings struct {
-	Message      string `json:"message"`
-	InstancePath string `json:"instancePath"`
-}
-
-// Any informational output given by a remote validator test.
-type rinfos struct {
-	Message      string `json:"message"`
-	InstancePath string `json:"instancePath"`
-}
-
-// Any error given by a remote validator test.
-type rerrors struct {
+// Any singular rtest given by a remote validator test.
+type remoteResults struct {
 	Message      string `json:"message"`
 	InstancePath string `json:"instancePath"`
 }
@@ -115,7 +102,6 @@ type remoteValidator struct {
 	url    string
 	tests  []test
 	cache  cache
-	output bool
 }
 
 // syncedRemoteValidator is a serialized variant of a remote validator.
@@ -223,7 +209,6 @@ func (rvo *RemoteValidatorOptions) Open() (RemoteValidator, error) {
 		url:    prepareURL(rvo.URL),
 		tests:  prepareTests(rvo.Presets),
 		cache:  cache,
-		output: rvo.Output,
 	}, nil
 }
 
@@ -296,13 +281,13 @@ func (v *remoteValidator) Validate(doc any) (bool, error) {
 		defer resp.Body.Close()
 		var in inDocument
 		err := json.NewDecoder(resp.Body).Decode(&in)
-		if v.output {
-			output, oerr := json.MarshalIndent(in, "", "    ")
-			if oerr != nil {
-				fmt.Println("Failed to display remote validator result.")
-			} else {
-				fmt.Println(string(output))
-			}
+//		if v.output {
+//			output, oerr := json.MarshalIndent(in, "", "    ")
+//			if oerr != nil {
+//				fmt.Println("Failed to display remote validator result.")
+//			} else {
+//				fmt.Println(string(output))
+//			}
 		}
 		return in.Valid, err
 	}()

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -32,8 +32,6 @@ var defaultPresets = []string{"mandatory"}
 
 var (
 	validationsBucket = []byte("validations")
-	validFalse        = []byte{0}
-	validTrue         = []byte{1}
 	versionOfBucket   = []byte("1")
 )
 

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -59,10 +59,11 @@ type outDocument struct {
 // rtest is the result of the remote tests
 // recieved by the remote validation service.
 type rtest struct {
-	Valid   bool        `json:"isValid"`
-	Warning []rwarnings `json:"warnings"`
 	Error   []rerrors   `json:"errors"`
 	Info    []rinfos    `json:"infos"`
+	Warning []rwarnings `json:"warnings"`
+	Valid   bool        `json:"isValid"`
+	Name    string      `json:"name"`
 }
 
 // Any warning given by a remote validator test.

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -260,18 +260,18 @@ func (v *remoteValidator) Validate(doc any) (RemoteValidationResult, error) {
 
 	var key []byte
 
-	var dummy RemoteValidationResult
-	dummy.Valid = false
+	var errorOutput RemoteValidationResult
+	errorOutput.Valid = false
 
 	if v.cache != nil {
 		var err error
 		if key, err = v.key(doc); err != nil {
-			return dummy, err
+			return errorOutput, err
 		}
 		valid, err := v.cache.get(key)
 		if err != errNotFound {
 			if err != nil {
-				return dummy, err
+				return errorOutput, err
 			}
 			return valid, nil
 		}
@@ -284,7 +284,7 @@ func (v *remoteValidator) Validate(doc any) (RemoteValidationResult, error) {
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(&o); err != nil {
-		return dummy, err
+		return errorOutput, err
 	}
 
 	resp, err := http.Post(
@@ -293,11 +293,11 @@ func (v *remoteValidator) Validate(doc any) (RemoteValidationResult, error) {
 		bytes.NewReader(buf.Bytes()))
 
 	if err != nil {
-		return dummy, err
+		return errorOutput, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return dummy, fmt.Errorf(
+		return errorOutput, fmt.Errorf(
 			"POST failed: %s (%d)", resp.Status, resp.StatusCode)
 	}
 
@@ -309,7 +309,7 @@ func (v *remoteValidator) Validate(doc any) (RemoteValidationResult, error) {
 	}()
 
 	if err != nil {
-		return dummy, err
+		return errorOutput, err
 	}
 
 	if key != nil {

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -56,7 +56,7 @@ type outDocument struct {
 	Document any    `json:"document"`
 }
 
-// Rtest is the result of the remote tests
+// RemoteTest is the result of the remote tests
 // recieved by the remote validation service.
 type RemoteTest struct {
 	Error   []RemoteTestResults `json:"errors"`

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -37,7 +37,7 @@ var (
 )
 
 // RemoteValidatorOptions are the configuation options
-// the remote validation service.
+// of the remote validation service.
 type RemoteValidatorOptions struct {
 	URL     string   `json:"url" toml:"url"`
 	Presets []string `json:"presets" toml:"presets"`
@@ -111,10 +111,10 @@ func SynchronizedRemoteValidator(validator RemoteValidator) RemoteValidator {
 
 // remoteValidator is an implementation of an RemoteValidator.
 type remoteValidator struct {
-	url   string
-	tests []test
-	cache cache
-        verbose bool
+	url     string
+	tests   []test
+	cache   cache
+	verbose bool
 }
 
 // syncedRemoteValidator is a serialized variant of a remote validator.
@@ -219,9 +219,9 @@ func (rvo *RemoteValidatorOptions) Open() (RemoteValidator, error) {
 		return nil, err
 	}
 	return &remoteValidator{
-		url:   prepareURL(rvo.URL),
-		tests: prepareTests(rvo.Presets),
-		cache: cache,
+		url:     prepareURL(rvo.URL),
+		tests:   prepareTests(rvo.Presets),
+		cache:   cache,
 		verbose: rvo.Verbose,
 	}, nil
 }

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -42,6 +42,7 @@ type RemoteValidatorOptions struct {
 	URL     string   `json:"url" toml:"url"`
 	Presets []string `json:"presets" toml:"presets"`
 	Cache   string   `json:"cache" toml:"cache"`
+	Verbose bool     `json:"verbose" toml:"verbose"`
 }
 
 type test struct {
@@ -113,6 +114,7 @@ type remoteValidator struct {
 	url   string
 	tests []test
 	cache cache
+        verbose bool
 }
 
 // syncedRemoteValidator is a serialized variant of a remote validator.
@@ -220,6 +222,7 @@ func (rvo *RemoteValidatorOptions) Open() (RemoteValidator, error) {
 		url:   prepareURL(rvo.URL),
 		tests: prepareTests(rvo.Presets),
 		cache: cache,
+		verbose: rvo.Verbose,
 	}, nil
 }
 
@@ -292,6 +295,14 @@ func (v *remoteValidator) Validate(doc any) (bool, error) {
 		defer resp.Body.Close()
 		var in inDocument
 		err := json.NewDecoder(resp.Body).Decode(&in)
+		if v.verbose {
+			verbose, verr := json.MarshalIndent(in, "", "    ")
+			if verr != nil {
+				fmt.Println("Failed to display remote validator result.")
+			} else {
+				fmt.Println(string(verbose))
+			}
+		}
 		return in.Valid, err
 	}()
 

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -66,7 +66,7 @@ type RemoteTest struct {
 	Name    string              `json:"name"`
 }
 
-// Any singular Rtest given by a remote validator test.
+// RemoteTestResults are any given test-result by a remote validator test.
 type RemoteTestResults struct {
 	Message      string `json:"message"`
 	InstancePath string `json:"instancePath"`

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -296,7 +296,7 @@ func (v *remoteValidator) Validate(doc any) (bool, error) {
 		defer resp.Body.Close()
 		var in inDocument
 		err := json.NewDecoder(resp.Body).Decode(&in)
-		if v.Output {
+		if v.output {
 			output, oerr := json.MarshalIndent(in, "", "    ")
 			if oerr != nil {
 				fmt.Println("Failed to display remote validator result.")

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -42,7 +42,7 @@ type RemoteValidatorOptions struct {
 	URL     string   `json:"url" toml:"url"`
 	Presets []string `json:"presets" toml:"presets"`
 	Cache   string   `json:"cache" toml:"cache"`
-	Verbose bool     `json:"verbose" toml:"verbose"`
+	Output  bool     `json:"output" toml:"output"`
 }
 
 type test struct {
@@ -115,7 +115,7 @@ type remoteValidator struct {
 	url     string
 	tests   []test
 	cache   cache
-	verbose bool
+	output bool
 }
 
 // syncedRemoteValidator is a serialized variant of a remote validator.
@@ -223,7 +223,7 @@ func (rvo *RemoteValidatorOptions) Open() (RemoteValidator, error) {
 		url:     prepareURL(rvo.URL),
 		tests:   prepareTests(rvo.Presets),
 		cache:   cache,
-		verbose: rvo.Verbose,
+		output:  rvo.Output,
 	}, nil
 }
 
@@ -296,12 +296,12 @@ func (v *remoteValidator) Validate(doc any) (bool, error) {
 		defer resp.Body.Close()
 		var in inDocument
 		err := json.NewDecoder(resp.Body).Decode(&in)
-		if v.verbose {
-			verbose, verr := json.MarshalIndent(in, "", "    ")
-			if verr != nil {
+		if v.Output {
+			output, oerr := json.MarshalIndent(in, "", "    ")
+			if oerr != nil {
 				fmt.Println("Failed to display remote validator result.")
 			} else {
-				fmt.Println(string(verbose))
+				fmt.Println(string(output))
 			}
 		}
 		return in.Valid, err

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -55,9 +55,37 @@ type outDocument struct {
 	Document any    `json:"document"`
 }
 
+// rtest is the result of the remote tests
+// recieved by the remote validation service.
+type rtest struct{
+	Valid bool `json:"isValid"`
+        Warning []rwarnings `json:"warnings"`
+	Error []rerrors `json:"errors"`
+	Info []rinfos `json:"infos"`
+}
+
+// Any warning given by a remote validator test.
+type rwarnings struct{
+	Message string `json:"message"`
+	InstancePath string `json:"instancePath"`
+}
+
+// Any informational output given by a remote validator test.
+type rinfos struct{
+	Message string `json:"message"`
+	InstancePath string `json:"instancePath"`
+}
+
+// Any error given by a remote validator test.
+type rerrors struct {
+	Message string `json:"message"`
+	InstancePath string `json:"instancePath"`
+}
+
 // inDocument is the document recieved from the remote validation service.
 type inDocument struct {
 	Valid bool `json:"isValid"`
+	Tests []rtest `json:"tests"`
 }
 
 var errNotFound = errors.New("not found")
@@ -263,7 +291,8 @@ func (v *remoteValidator) Validate(doc any) (bool, error) {
 	valid, err := func() (bool, error) {
 		defer resp.Body.Close()
 		var in inDocument
-		return in.Valid, json.NewDecoder(resp.Body).Decode(&in)
+		err := json.NewDecoder(resp.Body).Decode(&in)
+		return in.Valid, err
 	}()
 
 	if err != nil {

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -100,9 +100,9 @@ func SynchronizedRemoteValidator(validator RemoteValidator) RemoteValidator {
 
 // remoteValidator is an implementation of an RemoteValidator.
 type remoteValidator struct {
-	url    string
-	tests  []test
-	cache  cache
+	url   string
+	tests []test
+	cache cache
 }
 
 // syncedRemoteValidator is a serialized variant of a remote validator.
@@ -189,7 +189,6 @@ func prepareCache(config string) (cache, error) {
 	return boltCache{db}, nil
 }
 
-
 // boltCache is cache implementation based on the bolt datastore.
 type boltCache struct{ *bolt.DB }
 
@@ -233,9 +232,9 @@ func (rvo *RemoteValidatorOptions) Open() (RemoteValidator, error) {
 		return nil, err
 	}
 	return &remoteValidator{
-		url:    prepareURL(rvo.URL),
-		tests:  prepareTests(rvo.Presets),
-		cache:  cache,
+		url:   prepareURL(rvo.URL),
+		tests: prepareTests(rvo.Presets),
+		cache: cache,
 	}, nil
 }
 

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -128,7 +128,7 @@ languages or values of the branch category within the product tree you
 can set providers categories values. This can be done using an array
 of strings taken literally or, by prepending "expr:", have it be read
 through JSONPath values. For a more detailed explanation,
-[refer to the provider config.](csaf_provider.md)
+[refer to the provider config](csaf_provider.md#provider-options).
 
 #### Example config file
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/examples/aggregator.toml) -->

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -124,10 +124,11 @@ a `service.json` will be written listing its ROLIE feed documents.
 If it is not set or set to false, then no `service.json` will be written.
 
 To further dissect CSAF-documents by criteria like document category,
-languages or values of the branch category within the Product Tree you
-can set a providers categories value as an array of either
-literal categories or, by prepending "expr:", have it be read
-through JSONPath values.
+languages or values of the branch category within the product tree you
+can set providers categories values. This can be done using an array
+of strings taken literally or, by prepending "expr:", have it be read
+through JSONPath values. For a more detailed explanation,
+[refer to the provider config.](csaf_provider.md)
 
 #### Example config file
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/examples/aggregator.toml) -->

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -125,8 +125,9 @@ If it is not set or set to false, then no `service.json` will be written.
 
 To further dissect CSAF-documents by criteria like document category,
 languages or values of the branch category within the Product Tree you
-can set a providers categories value. This consists of an array of either
-literal category values or, by prepending "expr:", JSONPath values.
+can set a providers categories value as an array of either
+literal categories or, by prepending "expr:", have it be read
+through JSONPath values.
 
 #### Example config file
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/examples/aggregator.toml) -->

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -125,7 +125,7 @@ If it is not set or set to false, then no `service.json` will be written.
 
 To offer an easy way of assorting CSAF documents by criteria like 
 document category, languages or values of the branch category within
-the product tree ROLIE category values can be configured. This can either
+the product tree, ROLIE category values can be configured. This can either
 be done using an array of strings taken literally or, by prepending `"expr:"`. 
 The latter is evaluated as JSONPath and the result will be added into the 
 categories document. For a more detailed explanation and examples,

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -123,11 +123,12 @@ If a provider's `create_service_document` option is set to true,
 a `service.json` will be written listing its ROLIE feed documents.
 If it is not set or set to false, then no `service.json` will be written.
 
-To further dissect CSAF-documents by criteria like document category,
-languages or values of the branch category within the product tree you
-can set providers categories values. This can be done using an array
-of strings taken literally or, by prepending "expr:", have it be read
-through JSONPath values. For a more detailed explanation,
+To offer an easy way of assorting CSAF documents by criteria like 
+document category, languages or values of the branch category within
+the product tree ROLIE category values can be configured. This can either
+be done using an array of strings taken literally or, by prepending `"expr:"`. 
+The latter is evaluated as JSONPath and the result will be added into the 
+categories document. For a more detailed explanation and examples,
 [refer to the provider config](csaf_provider.md#provider-options).
 
 #### Example config file

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -119,6 +119,15 @@ This can be configured for each entry, by the config option with the same name.
 If not given it is taken from the configured default
 Otherwise, the internal default "on best effort" is used.
 
+If a provider's `create_service_document` option is set to true,
+a `service.json` will be written listing its ROLIE feed documents.
+If it is not set or set to false, then no `service.json` will be written.
+
+To further dissect CSAF-documents by criteria like document category,
+languages or values of the branch category within the Product Tree you
+can set a providers categories value. This consists of an array of either
+literal category values or, by prepending "expr:", JSONPath values.
+
 #### Example config file
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/examples/aggregator.toml) -->
 <!-- The below code snippet is automatically added from ../docs/examples/aggregator.toml -->
@@ -170,7 +179,7 @@ insecure = true
 #  rate = 1.8
 #  insecure = true
   write_indices = true
-  # If aggregator.category == "aggreator", set for an entry that should
+  # If aggregator.category == "aggregator", set for an entry that should
   # be listed in addition:
   category = "lister"
 ```

--- a/docs/csaf_validator.md
+++ b/docs/csaf_validator.md
@@ -8,11 +8,11 @@ is a tool to validate local advisories files against the JSON Schema and an opti
 csaf_validator [OPTIONS] files...
 
 Application Options:
-      --version                Display version of the binary
-      --validator=URL          URL to validate documents remotely
-      --validatorcache=FILE    FILE to cache remote validations
-      --validatorpreset=       One or more presets to validate remotely (default: mandatory)
-      --output=AMOUNT          If a remote validator was used, display the results in JSON format
+      --version                   Display version of the binary
+      --validator=URL             URL to validate documents remotely
+      --validatorcache=FILE       FILE to cache remote validations
+      --validatorpreset=          One or more presets to validate remotely (default: mandatory)
+      -o AMOUNT, --output=AMOUNT  If a remote validator was used, display the results in JSON format
 
 AMOUNT:
  all: Print the entire JSON output
@@ -20,5 +20,5 @@ AMOUNT:
  short: Print only the result, errors, warnings and infos.
 
 Help Options:
-  -h, --help                   Show this help message
+  -h, --help                      Show this help message
 ```

--- a/docs/csaf_validator.md
+++ b/docs/csaf_validator.md
@@ -12,7 +12,12 @@ Application Options:
       --validator=URL          URL to validate documents remotely
       --validatorcache=FILE    FILE to cache remote validations
       --validatorpreset=       One or more presets to validate remotely (default: mandatory)
-      --verbose                If a remote validator was used, display the results in JSON format
+      --output=AMOUNT          If a remote validator was used, display the results in JSON format
+
+AMOUNT:
+ all: Print the entire JSON output
+ important: Print the entire JSON output but omit all tests without errors, warnings and infos.
+ short: Print only errors, warnings and infos.
 
 Help Options:
   -h, --help                   Show this help message

--- a/docs/csaf_validator.md
+++ b/docs/csaf_validator.md
@@ -17,7 +17,7 @@ Application Options:
 AMOUNT:
  all: Print the entire JSON output
  important: Print the entire JSON output but omit all tests without errors, warnings and infos.
- short: Print only errors, warnings and infos.
+ short: Print only the result, errors, warnings and infos.
 
 Help Options:
   -h, --help                   Show this help message

--- a/docs/csaf_validator.md
+++ b/docs/csaf_validator.md
@@ -12,6 +12,7 @@ Application Options:
       --validator=URL          URL to validate documents remotely
       --validatorcache=FILE    FILE to cache remote validations
       --validatorpreset=       One or more presets to validate remotely (default: mandatory)
+      --verbose                If a remote validator was used, display the results in JSON format
 
 Help Options:
   -h, --help                   Show this help message


### PR DESCRIPTION
Solves https://github.com/csaf-poc/csaf_distribution/issues/324 by adding the --verbose flag to the csaf_validator.

Calling the validator with the verbose flag but without a remote validator currently has no effect. (The validator behaves as if verbose was not called)