### PR TITLE
Lockfile aggregator

### DIFF
--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -267,8 +267,10 @@ func (c *config) setDefaults() {
 		c.Domain = defaultDomain
 	}
 
-	if !c.NoLock && c.LockFile == nil {
-		c.LockFile = &defaultLockFile
+	if c.NoLock {
+		c.LockFile = nil
+	} else if c.LockFile == nil {
+		c.LockFile = &defautLockFile
 	}
 
 	if c.Workers <= 0 {

--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -32,10 +32,7 @@ const (
 	defaultWeb            = "/var/www/html"
 	defaultDomain         = "https://example.com"
 	defaultUpdateInterval = "on best effort"
-)
-
-var (
-	defaultLockFile = "/var/csaf_aggregator/run.lock"
+	defaultLockFile       = "/var/csaf_aggregator/run.lock"
 )
 
 type provider struct {
@@ -266,11 +263,11 @@ func (c *config) setDefaults() {
 		c.Domain = defaultDomain
 	}
 
-	if c.LockFile == nil {
-		c.LockFile = &defaultLockFile
-	}
-
-	if *c.LockFile == "" {
+	switch {
+	case c.LockFile == nil:
+		lockFile := defaultLockFile
+		c.LockFile = &lockFile
+	case *c.LockFile == "":
 		c.LockFile = nil
 	}
 

--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -270,7 +270,7 @@ func (c *config) setDefaults() {
 		c.LockFile = &defaultLockFile
 	}
 
-	if c.LockFile == "" {
+	if *c.LockFile == "" {
 		c.LockFile = nil
 	}
 

--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -34,6 +34,10 @@ const (
 	defaultUpdateInterval = "on best effort"
 )
 
+var (
+	defaultLockFile       = "/var/csaf_aggregator/run.lock"
+)
+
 type provider struct {
 	Name   string `toml:"name"`
 	Domain string `toml:"domain"`
@@ -71,6 +75,7 @@ type config struct {
 
 	// LockFile tries to lock to a given file.
 	LockFile *string `toml:"lock_file"`
+	NoLock   bool    `toml:"no_lock"`
 
 	// Interim performs an interim scan.
 	Interim bool `toml:"interim"`
@@ -260,6 +265,10 @@ func (c *config) setDefaults() {
 
 	if c.Domain == "" {
 		c.Domain = defaultDomain
+	}
+
+	if !c.NoLock && c.LockFile == nil {
+		c.LockFile = &defaultLockFile
 	}
 
 	if c.Workers <= 0 {

--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -32,7 +32,7 @@ const (
 	defaultWeb            = "/var/www/html"
 	defaultDomain         = "https://example.com"
 	defaultUpdateInterval = "on best effort"
-	defaultLockFile       = "/var/csaf_aggregator/run.lock"
+	defaultLockFile       = "/var/lock/csaf_aggregator/lock"
 )
 
 type provider struct {

--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -35,7 +35,7 @@ const (
 )
 
 var (
-	defaultLockFile       = "/var/csaf_aggregator/run.lock"
+	defaultLockFile = "/var/csaf_aggregator/run.lock"
 )
 
 type provider struct {

--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -270,7 +270,7 @@ func (c *config) setDefaults() {
 	if c.NoLock {
 		c.LockFile = nil
 	} else if c.LockFile == nil {
-		c.LockFile = &defautLockFile
+		c.LockFile = &defaultLockFile
 	}
 
 	if c.Workers <= 0 {

--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -75,7 +75,6 @@ type config struct {
 
 	// LockFile tries to lock to a given file.
 	LockFile *string `toml:"lock_file"`
-	NoLock   bool    `toml:"no_lock"`
 
 	// Interim performs an interim scan.
 	Interim bool `toml:"interim"`
@@ -267,10 +266,12 @@ func (c *config) setDefaults() {
 		c.Domain = defaultDomain
 	}
 
-	if c.NoLock {
-		c.LockFile = nil
-	} else if c.LockFile == nil {
+	if c.LockFile == nil {
 		c.LockFile = &defaultLockFile
+	}
+
+	if c.LockFile == "" {
+		c.LockFile = nil
 	}
 
 	if c.Workers <= 0 {

--- a/cmd/csaf_aggregator/main.go
+++ b/cmd/csaf_aggregator/main.go
@@ -46,7 +46,7 @@ func lock(lockFile *string, fn func() error) error {
 	}
 
 	if !locked {
-		return fmt.Errorf("cannot lock to file %s", *lockFile)
+		return fmt.Errorf("cannot aquire file lock at %s. Maybe the CSAF aggregator is already running?", *lockFile)
 	}
 	defer fl.Unlock()
 	return fn()

--- a/cmd/csaf_aggregator/main.go
+++ b/cmd/csaf_aggregator/main.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/csaf-poc/csaf_distribution/util"
 	"github.com/gofrs/flock"
@@ -39,6 +40,12 @@ func lock(lockFile *string, fn func() error) error {
 		// No locking configured.
 		return fn()
 	}
+
+	err := os.MkdirAll(filepath.Dir(*lockFile), 0700)
+	if err != nil {
+		return fmt.Errorf("file locking failed: %v", err)
+	}
+
 	fl := flock.New(*lockFile)
 	locked, err := fl.TryLock()
 	if err != nil {

--- a/cmd/csaf_aggregator/main.go
+++ b/cmd/csaf_aggregator/main.go
@@ -53,7 +53,7 @@ func lock(lockFile *string, fn func() error) error {
 	}
 
 	if !locked {
-		return fmt.Errorf("cannot aquire file lock at %s. Maybe the CSAF aggregator is already running?", *lockFile)
+		return fmt.Errorf("cannot acquire file lock at %s. Maybe the CSAF aggregator is already running?", *lockFile)
 	}
 	defer fl.Unlock()
 	return fn()

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -91,7 +91,8 @@ openpgp_private_key     // OpenPGP private key (must have no passphrase set, if
                         // you want to be able to run unattended, e.g. via cron.)
 openpgp_public_key      // OpenPGP public key
 passphrase              // passphrase of the OpenPGP key
-lock_file               // path to lockfile, to stop other instances if one is not done (default no locking)
+lock_file               // path to lockfile, to stop other instances if one is not done (default:run.lock)
+no_lock                 // explicitely disable usage of lock files. (default: false)
 interim_years           // limiting the years for which interim documents are searched (default 0)
 verbose                 // print more diagnostic output, e.g. https requests (default false)
 allow_single_provider   // debugging option (default false)
@@ -158,6 +159,7 @@ categories document. For a more detailed explanation and examples,
 workers = 2
 folder = "/var/csaf_aggregator"
 lock_file = "/var/csaf_aggregator/run.lock"
+#no_lock = false
 web = "/var/csaf_aggregator/html"
 domain = "https://localhost:9443"
 rate = 10.0

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -91,8 +91,7 @@ openpgp_private_key     // OpenPGP private key (must have no passphrase set, if
                         // you want to be able to run unattended, e.g. via cron.)
 openpgp_public_key      // OpenPGP public key
 passphrase              // passphrase of the OpenPGP key
-lock_file               // path to lockfile, to stop other instances if one is not done (default:/var/csaf_aggregator/run.lock)
-no_lock                 // explicitely disable usage of lock files. (default: false)
+lock_file               // path to lockfile, to stop other instances if one is not done (default:/var/csaf_aggregator/run.lock, disable by setting it to "")
 interim_years           // limiting the years for which interim documents are searched (default 0)
 verbose                 // print more diagnostic output, e.g. https requests (default false)
 allow_single_provider   // debugging option (default false)
@@ -159,7 +158,6 @@ categories document. For a more detailed explanation and examples,
 workers = 2
 folder = "/var/csaf_aggregator"
 lock_file = "/var/csaf_aggregator/run.lock"
-#no_lock = false
 web = "/var/csaf_aggregator/html"
 domain = "https://localhost:9443"
 rate = 10.0

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -91,7 +91,7 @@ openpgp_private_key     // OpenPGP private key (must have no passphrase set, if
                         // you want to be able to run unattended, e.g. via cron.)
 openpgp_public_key      // OpenPGP public key
 passphrase              // passphrase of the OpenPGP key
-lock_file               // path to lockfile, to stop other instances if one is not done (default:/var/csaf_aggregator/run.lock, disable by setting it to "")
+lock_file               // path to lockfile, to stop other instances if one is not done (default:/var/lock/csaf_aggregator/lock, disable by setting it to "")
 interim_years           // limiting the years for which interim documents are searched (default 0)
 verbose                 // print more diagnostic output, e.g. https requests (default false)
 allow_single_provider   // debugging option (default false)

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -91,7 +91,7 @@ openpgp_private_key     // OpenPGP private key (must have no passphrase set, if
                         // you want to be able to run unattended, e.g. via cron.)
 openpgp_public_key      // OpenPGP public key
 passphrase              // passphrase of the OpenPGP key
-lock_file               // path to lockfile, to stop other instances if one is not done (default:run.lock)
+lock_file               // path to lockfile, to stop other instances if one is not done (default:/var/csaf_aggregator/run.lock)
 no_lock                 // explicitely disable usage of lock files. (default: false)
 interim_years           // limiting the years for which interim documents are searched (default 0)
 verbose                 // print more diagnostic output, e.g. https requests (default false)

--- a/docs/examples/aggregator.toml
+++ b/docs/examples/aggregator.toml
@@ -1,6 +1,6 @@
 workers = 2
 folder = "/var/csaf_aggregator"
-lock_file = "/var/csaf_aggregator/run.lock"
+lock_file = "/var/lock/csaf_aggregator/lock"
 web = "/var/csaf_aggregator/html"
 domain = "https://localhost:9443"
 rate = 10.0

--- a/docs/examples/aggregator.toml
+++ b/docs/examples/aggregator.toml
@@ -1,6 +1,7 @@
 workers = 2
 folder = "/var/csaf_aggregator"
 lock_file = "/var/csaf_aggregator/run.lock"
+#no_lock = false
 web = "/var/csaf_aggregator/html"
 domain = "https://localhost:9443"
 rate = 10.0

--- a/docs/examples/aggregator.toml
+++ b/docs/examples/aggregator.toml
@@ -1,7 +1,6 @@
 workers = 2
 folder = "/var/csaf_aggregator"
 lock_file = "/var/csaf_aggregator/run.lock"
-#no_lock = false
 web = "/var/csaf_aggregator/html"
 domain = "https://localhost:9443"
 rate = 10.0


### PR DESCRIPTION
Adds option no_lock to csaf_aggregator. If set to true, no lockfile will be used. If no_lock is false, the configs lockfile will be used. If no lockfile is specified, /var/csaf_aggregator/run.lock will be used as default.

Solves https://github.com/csaf-poc/csaf_distribution/issues/344