### PR TITLE
Fix header client. Simplify code.

### DIFF
--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -916,7 +916,7 @@ func (p *processor) checkChanges(base string, mask whereType) error {
 	return p.integrity(files, base, mask, p.badChanges.add)
 }
 
-func (p *processor) processROLIEFeeds(domain string, feeds [][]csaf.Feed) error {
+func (p *processor) processROLIEFeeds(feeds [][]csaf.Feed) error {
 
 	base, err := url.Parse(p.pmdURL)
 	if err != nil {
@@ -953,7 +953,7 @@ func empty(arr []string) bool {
 	return true
 }
 
-func (p *processor) checkCSAFs(domain string) error {
+func (p *processor) checkCSAFs(_ string) error {
 	// Check for ROLIE
 	rolie, err := p.expr.Eval("$.distributions[*].rolie.feeds", p.pmd)
 	if err != nil {
@@ -967,7 +967,7 @@ func (p *processor) checkCSAFs(domain string) error {
 		var feeds [][]csaf.Feed
 		if err := util.ReMarshalJSON(&feeds, rolie); err != nil {
 			p.badProviderMetadata.error("ROLIE feeds are not compatible: %v.", err)
-		} else if err := p.processROLIEFeeds(domain, feeds); err != nil {
+		} else if err := p.processROLIEFeeds(feeds); err != nil {
 			if err != errContinue {
 				return err
 			}
@@ -1299,7 +1299,7 @@ func (p *processor) checkWellknownSecurityDNS(domain string) error {
 // the the remotely keys and compares the fingerprints.
 // As a result of these a respective error messages are passed to badPGP method
 // in case of errors. It returns nil if all checks are passed.
-func (p *processor) checkPGPKeys(domain string) error {
+func (p *processor) checkPGPKeys(_ string) error {
 
 	p.badPGPs.use()
 

--- a/cmd/csaf_provider/controller.go
+++ b/cmd/csaf_provider/controller.go
@@ -147,7 +147,7 @@ func (c *controller) failed(rw http.ResponseWriter, tmpl string, err error) {
 }
 
 // index calls the "render" function and passes the "index.html" and c.cfg to it.
-func (c *controller) index(rw http.ResponseWriter, r *http.Request) {
+func (c *controller) index(rw http.ResponseWriter, _ *http.Request) {
 	c.render(rw, "index.html", map[string]any{
 		"Config": c.cfg,
 	})

--- a/cmd/csaf_provider/files.go
+++ b/cmd/csaf_provider/files.go
@@ -30,8 +30,5 @@ func writeHashedFile(fname, name string, data []byte, armored string) error {
 		return err
 	}
 	// Write signature.
-	if err := os.WriteFile(fname+".asc", []byte(armored), 0644); err != nil {
-		return err
-	}
-	return nil
+	return os.WriteFile(fname+".asc", []byte(armored), 0644)
 }

--- a/csaf/models.go
+++ b/csaf/models.go
@@ -298,10 +298,7 @@ func (acp *AggregatorCSAFProvider) Validate() error {
 	if acp == nil {
 		return errors.New("aggregator.csaf_providers[] not allowed to be nil")
 	}
-	if err := acp.Metadata.Validate(); err != nil {
-		return err
-	}
-	return nil
+	return acp.Metadata.Validate()
 }
 
 // Validate validates the current state of the Aggregator.

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -163,10 +163,7 @@ func prepareCache(config string) (cache, error) {
 			if err != nil {
 				return err
 			}
-			if err := b.Put(cacheVersionKey, cacheVersion); err != nil {
-				return err
-			}
-			return nil
+			return b.Put(cacheVersionKey, cacheVersion)
 		}
 
 		b := tx.Bucket(validationsBucket)

--- a/util/client.go
+++ b/util/client.go
@@ -83,7 +83,7 @@ func (hc *HeaderClient) Head(url string) (*http.Response, error) {
 
 // Post implements the respective method of the [Client] interface.
 func (hc *HeaderClient) Post(url, contentType string, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequest(http.MethodPost, url, nil)
+	req, err := http.NewRequest(http.MethodPost, url, body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The util.HeaderClient POST request was broken.
The body of the send request was not send at all.

This PR fixes this and also simplifies the code
at some other places.

This was found by a newer version of `revive`.