### PR TITLE
Add revive action to workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,5 +30,8 @@ jobs:
       - name: golint
         uses: Jerome1337/golint-action@v1.0.2
 
+      - name: Revive Action
+        uses: morphy2k/revive-action@v2.5.1
+
       - name: Tests
         run: go test -v ./...


### PR DESCRIPTION
What:

Add revive action to github actions as described in https://github.com/marketplace/actions/revive-action 

Why:

Revive can catch potential mistakes and poorly written code. Solves  https://github.com/csaf-poc/csaf_distribution/issues/353