### PR TITLE
Rephrase csaf validation result

### DIFF
--- a/cmd/csaf_checker/reporters.go
+++ b/cmd/csaf_checker/reporters.go
@@ -49,12 +49,12 @@ func (bc *baseReporter) requirement(domain *Domain) *Requirement {
 func (r *validReporter) report(p *processor, domain *Domain) {
 	req := r.requirement(domain)
 	if p.validator == nil {
-		req.message(InfoType, "No remote validator configured")
+		req.message(WarnType, "No remote validator configured")
 	}
 	if !p.invalidAdvisories.used() {
 		req.message(InfoType, "No validations performed")
 	} else if len(p.invalidAdvisories) == 0 {
-		req.message(InfoType, "All advisories validated fine.")
+		req.message(InfoType, "All advisories validated fine against the schema.")
 	} else {
 		req.Append(p.invalidAdvisories)
 	}

--- a/cmd/csaf_checker/reporters.go
+++ b/cmd/csaf_checker/reporters.go
@@ -46,7 +46,7 @@ func (bc *baseReporter) requirement(domain *Domain) *Requirement {
 }
 
 // contains returns whether an array of strings contains a given string.
-func contains(o [] string, p string) bool {
+func contains(o []string, p string) bool {
 	for _, option := range o {
 		if option == p {
 			return true
@@ -68,7 +68,7 @@ func (r *validReporter) report(p *processor, domain *Domain) {
 			req.message(InfoType, "All advisories validated fine.")
 		} else {
 			req.message(InfoType, "All advisories validated fine against the schema.")
-			}
+		}
 	} else {
 		req.Append(p.invalidAdvisories)
 	}

--- a/cmd/csaf_checker/reporters.go
+++ b/cmd/csaf_checker/reporters.go
@@ -45,6 +45,16 @@ func (bc *baseReporter) requirement(domain *Domain) *Requirement {
 	return req
 }
 
+// contains returns whether an array of strings contains a given string.
+func contains(o [] string, p string) bool {
+	for _, option := range o {
+		if option == p {
+			return true
+		}
+	}
+	return false
+}
+
 // report reports if there where any invalid filenames,
 func (r *validReporter) report(p *processor, domain *Domain) {
 	req := r.requirement(domain)
@@ -54,7 +64,11 @@ func (r *validReporter) report(p *processor, domain *Domain) {
 	if !p.invalidAdvisories.used() {
 		req.message(InfoType, "No validations performed")
 	} else if len(p.invalidAdvisories) == 0 {
-		req.message(InfoType, "All advisories validated fine against the schema.")
+		if (p.validator != nil) && (contains(p.opts.RemoteValidatorPresets, "mandatory") || contains(p.opts.RemoteValidatorPresets, "basic") || contains(p.opts.RemoteValidatorPresets, "extended") || contains(p.opts.RemoteValidatorPresets, "full")) {
+			req.message(InfoType, "All advisories validated fine.")
+		} else {
+			req.message(InfoType, "All advisories validated fine against the schema.")
+			}
 	} else {
 		req.Append(p.invalidAdvisories)
 	}


### PR DESCRIPTION
Give out a warning if no remote validator is configured.

Clarify that the inbuild validator only validates against the schema.

Solves https://github.com/csaf-poc/csaf_distribution/issues/338