### PR TITLE
Add concurrent downloads to downloader.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.1
+          go-version: 1.20.3
 
       - name: Build
         run: go build -v ./cmd/...

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: 1.20.3
 
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-            go-version: '^1.19.1'
+            go-version: '^1.20.3'
 
       - name: Build
         run: make dist

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -274,8 +274,12 @@ func (d *downloader) downloadFiles(
 
 		for {
 			var file csaf.AdvisoryFile
+			var ok bool
 			select {
-			case file = <-filesCh:
+			case file, ok = <-filesCh:
+				if !ok {
+					return
+				}
 			case <-ctx.Done():
 				return
 			}
@@ -469,6 +473,7 @@ allFiles:
 			break allFiles
 		}
 	}
+	close(filesCh)
 	wg.Wait()
 	return errors.Join(exitErrs...)
 }

--- a/cmd/csaf_downloader/main.go
+++ b/cmd/csaf_downloader/main.go
@@ -24,12 +24,13 @@ import (
 const defaultWorker = 1
 
 type options struct {
-	Directory *string  `short:"d" long:"directory" description:"DIRectory to store the downloaded files in" value-name:"DIR"`
-	Insecure  bool     `long:"insecure" description:"Do not check TLS certificates from provider"`
-	Version   bool     `long:"version" description:"Display version of the binary"`
-	Verbose   bool     `long:"verbose" short:"v" description:"Verbose output"`
-	Rate      *float64 `long:"rate" short:"r" description:"The average upper limit of https operations per second"`
-	Worker    int      `long:"worker" short:"w" description:"Number of concurrent downloads" default:"1"`
+	Directory            *string  `short:"d" long:"directory" description:"DIRectory to store the downloaded files in" value-name:"DIR"`
+	Insecure             bool     `long:"insecure" description:"Do not check TLS certificates from provider"`
+	IgnoreSignatureCheck bool     `long:"ignoresigcheck" description:"Ignore signature check results, just warn on mismatch"`
+	Version              bool     `long:"version" description:"Display version of the binary"`
+	Verbose              bool     `long:"verbose" short:"v" description:"Verbose output"`
+	Rate                 *float64 `long:"rate" short:"r" description:"The average upper limit of https operations per second"`
+	Worker               int      `long:"worker" short:"w" description:"NUMber of concurrent downloads" value-name:"NUM"`
 
 	ExtraHeader http.Header `long:"header" short:"H" description:"One or more extra HTTP header fields"`
 

--- a/cmd/csaf_downloader/main.go
+++ b/cmd/csaf_downloader/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-const defaultWorker = 1
+const defaultWorker = 2
 
 type options struct {
 	Directory            *string  `short:"d" long:"directory" description:"DIRectory to store the downloaded files in" value-name:"DIR"`

--- a/docs/csaf_downloader.md
+++ b/docs/csaf_downloader.md
@@ -13,7 +13,7 @@ Application Options:
       --version                Display version of the binary
   -v, --verbose                Verbose output
   -r, --rate=                  The average upper limit of https operations per second (defaults to unlimited)
-  -w, --worker=NUM             NUMber of concurrent downloads (default: 1)
+  -w, --worker=NUM             NUMber of concurrent downloads (default: 2)
   -H, --header=                One or more extra HTTP header fields
       --validator=URL          URL to validate documents remotely
       --validatorcache=FILE    FILE to cache remote validations

--- a/docs/csaf_downloader.md
+++ b/docs/csaf_downloader.md
@@ -12,6 +12,7 @@ Application Options:
       --version                Display version of the binary
   -v, --verbose                Verbose output
   -r, --rate=                  The average upper limit of https operations per second
+  -w, --worker=                Number of concurrent downloads (default: 1)
   -H, --header=                One or more extra HTTP header fields
       --validator=URL          URL to validate documents remotely
       --validatorcache=FILE    FILE to cache remote validations

--- a/docs/csaf_downloader.md
+++ b/docs/csaf_downloader.md
@@ -9,10 +9,11 @@ csaf_downloader [OPTIONS] domain...
 Application Options:
   -d, --directory=DIR          DIRectory to store the downloaded files in
       --insecure               Do not check TLS certificates from provider
+      --ignoresigcheck         Ignore signature check results, just warn on mismatch
       --version                Display version of the binary
   -v, --verbose                Verbose output
   -r, --rate=                  The average upper limit of https operations per second
-  -w, --worker=                Number of concurrent downloads (default: 1)
+  -w, --worker=NUM             NUMber of concurrent downloads (default: 1)
   -H, --header=                One or more extra HTTP header fields
       --validator=URL          URL to validate documents remotely
       --validatorcache=FILE    FILE to cache remote validations
@@ -25,3 +26,8 @@ Help Options:
 Will download all CSAF documents for the given _domains_, by trying each as a CSAF provider.
 
 If a _domain_ starts with `https://` it is instead considered a direct URL to the `provider-metadata.json` and downloading procedes from there.
+
+Increasing the number of workers opens more connections to the web servers
+to download more advisories at once. This may improve the overall speed of the download.
+However, since this also increases the load on the servers, their administrators could
+have taken countermeasures to limit this.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/csaf-poc/csaf_distribution
 
-go 1.19
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
Add `--worker` flag to downloader.

Some sites seems to limit the number of requests per time interval per http client.
This PR adds a flag to download more than one advisory at once via multiple
http clients to speed up the process. By default only two clients are used.

Furthermore this PR also adds the feature to stop the downloader by `Ctrl-C`ing.

When the `ignoresigcheck` flag is set the results of the signature checks are ignored.

Bumped Go to 1.20 to use `errors.Join`.