### PR TITLE
doc: improve rate default documentation

### DIFF
--- a/cmd/csaf_checker/main.go
+++ b/cmd/csaf_checker/main.go
@@ -37,7 +37,7 @@ type options struct {
 	ClientKey   *string     `long:"client-key" description:"TLS client private key file (PEM encoded data)" value-name:"KEY-FILE"`
 	Version     bool        `long:"version" description:"Display version of the binary"`
 	Verbose     bool        `long:"verbose" short:"v" description:"Verbose output"`
-	Rate        *float64    `long:"rate" short:"r" description:"The average upper limit of https operations per second"`
+	Rate        *float64    `long:"rate" short:"r" description:"The average upper limit of https operations per second (defaults to unlimited)"`
 	Years       *uint       `long:"years" short:"y" description:"Number of years to look back from now" value-name:"YEARS"`
 	ExtraHeader http.Header `long:"header" short:"H" description:"One or more extra HTTP header fields"`
 

--- a/cmd/csaf_downloader/main.go
+++ b/cmd/csaf_downloader/main.go
@@ -24,7 +24,7 @@ type options struct {
 	Insecure  bool     `long:"insecure" description:"Do not check TLS certificates from provider"`
 	Version   bool     `long:"version" description:"Display version of the binary"`
 	Verbose   bool     `long:"verbose" short:"v" description:"Verbose output"`
-	Rate      *float64 `long:"rate" short:"r" description:"The average upper limit of https operations per second"`
+	Rate      *float64 `long:"rate" short:"r" description:"The average upper limit of https operations per second (defaults to unlimited)"`
 
 	ExtraHeader http.Header `long:"header" short:"H" description:"One or more extra HTTP header fields"`
 

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -81,7 +81,7 @@ workers                 // number of parallel workers to start (default 10)
 folder                  // target folder on disc for writing the downloaded documents (default "/var/www")
 web                     // directory to be served by the webserver (default "/var/www/html")
 domain                  // base url where the contents will be reachable from outside (default "https://example.com")
-rate                    // downloading limit per worker in HTTPS req/s (default: no limiting)
+rate                    // downloading limit per worker in HTTPS req/s (defaults to unlimited)
 insecure                // do not check validity of TLS certificates
 write_indices           // write index.txt and changes.csv
 update_interval         // to indicate the collection interval for a provider (default ""on best effort")

--- a/docs/csaf_checker.md
+++ b/docs/csaf_checker.md
@@ -14,7 +14,7 @@ Application Options:
       --client-key=KEY-FILE      TLS client private key file (PEM encoded data)
       --version                  Display version of the binary
   -v, --verbose                  Verbose output
-  -r, --rate=                    The average upper limit of https operations per second (defaults to unlimited)"
+  -r, --rate=                    The average upper limit of https operations per second (defaults to unlimited)
   -y, --years=YEARS              Number of years to look back from now
   -H, --header=                  One or more extra HTTP header fields
       --validator=URL            URL to validate documents remotely

--- a/docs/csaf_checker.md
+++ b/docs/csaf_checker.md
@@ -14,7 +14,7 @@ Application Options:
       --client-key=KEY-FILE      TLS client private key file (PEM encoded data)
       --version                  Display version of the binary
   -v, --verbose                  Verbose output
-  -r, --rate=                    The average upper limit of https operations per second
+  -r, --rate=                    The average upper limit of https operations per second (defaults to unlimited)"
   -y, --years=YEARS              Number of years to look back from now
   -H, --header=                  One or more extra HTTP header fields
       --validator=URL            URL to validate documents remotely
@@ -28,7 +28,7 @@ Help Options:
 
 Will check all given _domains_, by trying each as a CSAF provider.
 
-If a _domain_ starts with `https://` it is instead considered a direct URL to the `provider-metadata.json` and checking procedes from there.
+If a _domain_ starts with `https://` it is instead considered a direct URL to the `provider-metadata.json` and checking proceeds from there.
 
 
 Usage example:

--- a/docs/csaf_downloader.md
+++ b/docs/csaf_downloader.md
@@ -11,7 +11,7 @@ Application Options:
       --insecure               Do not check TLS certificates from provider
       --version                Display version of the binary
   -v, --verbose                Verbose output
-  -r, --rate=                  The average upper limit of https operations per second
+  -r, --rate=                  The average upper limit of https operations per second (defaults to unlimited)
   -H, --header=                One or more extra HTTP header fields
       --validator=URL          URL to validate documents remotely
       --validatorcache=FILE    FILE to cache remote validations


### PR DESCRIPTION
 * add rate default to download and checker options, using the description field
 in the struct tag because we leave the value at nil by default.
 * use the same phrasing in the aggregator docs to be consistent

solve #359