### PR TITLE
Check that filename matches /document/tracking/id

### DIFF
--- a/cmd/csaf_aggregator/mirror.go
+++ b/cmd/csaf_aggregator/mirror.go
@@ -557,6 +557,11 @@ func (w *worker) mirrorFiles(tlpLabel csaf.TLPLabel, files []csaf.AdvisoryFile) 
 			continue
 		}
 
+		if util.CleanFileName(sum.ID) != filename {
+			log.Printf("ID %q does not match filename %s",
+				sum.ID, filename)
+		}
+
 		if err := w.extractCategories(label, advisory); err != nil {
 			log.Printf("error: %s: %v\n", file, err)
 			continue

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -423,7 +423,6 @@ func (p *processor) integrity(
 	client := p.httpClient()
 
 	var data bytes.Buffer
-	eval := util.NewPathEval()
 
 	makeAbs := func(u *url.URL) *url.URL {
 		if u.IsAbs() {
@@ -513,8 +512,7 @@ func (p *processor) integrity(
 			p.invalidAdvisories.error("CSAF file %s has %d validation errors.", u, len(errors))
 		}
 
-		if err := util.IDMatchesFilename(eval, doc, filepath.Base(u)); err != nil {
-
+		if err := util.IDMatchesFilename(p.expr, doc, filepath.Base(u)); err != nil {
 			p.invalidAdvisories.error("%s: %v\n", u, err)
 			continue
 

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -423,6 +423,7 @@ func (p *processor) integrity(
 	client := p.httpClient()
 
 	var data bytes.Buffer
+	eval := util.NewPathEval()
 
 	makeAbs := func(u *url.URL) *url.URL {
 		if u.IsAbs() {
@@ -510,6 +511,13 @@ func (p *processor) integrity(
 		}
 		if len(errors) > 0 {
 			p.invalidAdvisories.error("CSAF file %s has %d validation errors.", u, len(errors))
+		}
+
+		if err := util.IDMatchesFilename(eval, doc, filepath.Base(u)); err != nil {
+
+			p.invalidAdvisories.error("%s: %v\n", u, err)
+			continue
+
 		}
 
 		// Validate against remote validator.

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -368,6 +368,11 @@ func (d *downloader) downloadFiles(label csaf.TLPLabel, files []csaf.AdvisoryFil
 			continue
 		}
 
+		if err := util.IDMatchesFilename(d.eval, doc, filename); err != nil {
+			log.Printf("Ignoring %s: %s.\n", file.URL(), err)
+			continue
+		}
+
 		// Validate against remote validator
 		if d.validator != nil {
 			rvr, err := d.validator.Validate(doc)

--- a/cmd/csaf_provider/actions.go
+++ b/cmd/csaf_provider/actions.go
@@ -196,6 +196,11 @@ func (c *controller) upload(r *http.Request) (any, error) {
 		return nil, err
 	}
 
+	if util.CleanFileName(ex.ID) != newCSAF {
+		return nil, fmt.Errorf("ID %q does not match filename %s",
+			ex.ID, newCSAF)
+	}
+
 	// Check if we have to search for dynamic categories.
 	var dynamicCategories []string
 	if catExprs := c.cfg.DynamicCategories(); len(catExprs) > 0 {

--- a/cmd/csaf_uploader/main.go
+++ b/cmd/csaf_uploader/main.go
@@ -243,6 +243,11 @@ func (p *processor) uploadRequest(filename string) (*http.Request, error) {
 			writeStrings("Errors:", errs)
 			return nil, errors.New("local schema check failed")
 		}
+
+		eval := util.NewPathEval()
+		if err := util.IDMatchesFilename(eval, doc, filepath.Base(filename)); err != nil {
+			return nil, err
+		}
 	}
 
 	body := new(bytes.Buffer)

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -54,6 +54,7 @@ func main() {
 func run(opts *options, files []string) error {
 
 	var validator csaf.RemoteValidator
+	eval := util.NewPathEval()
 
 	if opts.RemoteValidator != "" {
 		validatorOptions := csaf.RemoteValidatorOptions{
@@ -109,6 +110,13 @@ func run(opts *options, files []string) error {
 		} else {
 			fmt.Printf("%q passes the schema validation.\n", file)
 		}
+
+		// Check filename agains ID
+		if err := util.IDMatchesFilename(eval, doc, filepath.Base(file)); err != nil {
+			log.Printf("%s: %s.\n", file, err)
+			continue
+		}
+
 		// Validate against remote validator.
 		if validator != nil {
 			rvr, err := validator.Validate(doc)

--- a/util/file.go
+++ b/util/file.go
@@ -9,6 +9,7 @@
 package util
 
 import (
+	"fmt"
 	"io"
 	"math/rand"
 	"os"
@@ -36,6 +37,23 @@ func CleanFileName(s string) string {
 // ConformingFileName checks if the given filename conforms to the standard.
 func ConformingFileName(fname string) bool {
 	return fname == CleanFileName(fname)
+}
+
+// IDMatchesFilename checks that filename can be derived from the value
+// of document/tracking/id extracted from doc using eval.
+// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#51-filename
+func IDMatchesFilename(eval *PathEval, doc any, filename string) error {
+	var id string
+	if err := eval.Extract(`$.document.tracking.id`, StringMatcher(&id), false, doc); err != nil {
+		return fmt.Errorf("check that ID matches filename: %v", err)
+	}
+
+	if CleanFileName(id) != filename {
+		return fmt.Errorf("document/tracking/id %q does not match filename %s",
+			id, filename)
+	}
+
+	return nil
 }
 
 // PathExists returns true if path exits.


### PR DESCRIPTION
Implement #325: Check that the filename matches the ID according to the
rules in Section 5.1. All places where the code already checks the
filename syntax the code now checks that it also matches the ID.

There's one exception to this in the `csaf_uploader` where the this
additional check is only done when schema checks are enabled. That was
done for simplicity of implementation because only in that case does the
uploader parse the CSAF file.
