### PR TITLE
Fix pmd crash

### DIFF
--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -231,13 +231,16 @@ func (p *processor) run(domains []string) (*Report, error) {
 	}
 
 	for _, d := range domains {
-		if p.checkProviderMetadata(d) {
-			if err := p.checkDomain(d); err != nil {
-				if err == errContinue || err == errStop {
-					continue
-				}
-				return nil, err
+		if !p.checkProviderMetadata(d) {
+			// We cannot build a report if the provider metadata cannot be parsed.
+			log.Printf("Could not parse the Provider-Metadata.json of %s", d)
+			continue
+		}
+		if err := p.checkDomain(d); err != nil {
+			if err == errContinue || err == errStop {
+				continue
 			}
+			return nil, err
 		}
 		domain := &Domain{Name: d}
 

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -233,7 +233,7 @@ func (p *processor) run(domains []string) (*Report, error) {
 	for _, d := range domains {
 		if !p.checkProviderMetadata(d) {
 			// We cannot build a report if the provider metadata cannot be parsed.
-			log.Printf("Could not parse the Provider-Metadata.json of %s", d)
+			log.Printf("Could not parse the Provider-Metadata.json of: %s\n", d)
 			continue
 		}
 		if err := p.checkDomain(d); err != nil {

--- a/cmd/csaf_checker/reporters.go
+++ b/cmd/csaf_checker/reporters.go
@@ -270,7 +270,7 @@ func (r *providerMetadataReport) report(p *processor, domain *Domain) {
 func (r *securityReporter) report(p *processor, domain *Domain) {
 	req := r.requirement(domain)
 	if !p.badSecurity.used() {
-		req.message(InfoType, "Performed no in-depth test of security.txt.")
+		req.message(WarnType, "Performed no in-depth test of security.txt.")
 		return
 	}
 	if len(p.badSecurity) == 0 {
@@ -284,7 +284,7 @@ func (r *securityReporter) report(p *processor, domain *Domain) {
 func (r *wellknownMetadataReporter) report(p *processor, domain *Domain) {
 	req := r.requirement(domain)
 	if !p.badWellknownMetadata.used() {
-		req.message(InfoType, "Since no valid provider-metadata.json was found, no extended check was performed.")
+		req.message(WarnType, "Since no valid provider-metadata.json was found, no extended check was performed.")
 		return
 	}
 	if len(p.badWellknownMetadata) == 0 {
@@ -298,7 +298,7 @@ func (r *wellknownMetadataReporter) report(p *processor, domain *Domain) {
 func (r *dnsPathReporter) report(p *processor, domain *Domain) {
 	req := r.requirement(domain)
 	if !p.badDNSPath.used() {
-		req.message(InfoType, "No check about contents from https://csaf.data.security.DOMAIN performed.")
+		req.message(WarnType, "No check about contents from https://csaf.data.security.DOMAIN performed.")
 		return
 	}
 	if len(p.badDNSPath) == 0 {


### PR DESCRIPTION
Currently, trying to check an invalid provider-metadata.json leads to a crash. (It causes a nullpointerreference when ranging over *domain.Role in line 250 of csaf_checker/processor.go): 

    for _, r := range buildReporters(*domain.Role) {
        r.report(p, domain)
    }

This PR adds logging output that the provider-metadata.json of that domain couldn't be parsed and then continues onto the next domain instead of trying to build relevant reporters.

This should also address https://github.com/csaf-poc/csaf_distribution/issues/251