### PR TITLE
We need at least Go 1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Download the binaries from the most recent release assets on Github.
 
 ### Build from sources
 
-- A recent version of **Go** (1.19.1+) should be installed. [Go installation](https://go.dev/doc/install)
+- A recent version of **Go** (1.20+) should be installed. [Go installation](https://go.dev/doc/install)
 
 - Clone the repository `git clone https://github.com/csaf-poc/csaf_distribution.git `
 


### PR DESCRIPTION
We need at least Go 1.20 but the README still talks about 1.19.1.
This PR is fixing this.