### PR TITLE
Dont use string comparison to rank labels.

### DIFF
--- a/cmd/csaf_checker/roliecheck.go
+++ b/cmd/csaf_checker/roliecheck.go
@@ -107,7 +107,7 @@ func (rlc *rolieLabelChecker) checkProtection(
 	// the data again with the open client.
 	// If this does not result in status forbidden the
 	// server may be wrongly configured.
-	case label >= csaf.TLPLabelAmber:
+	case tlpLevel(label) >= tlpLevel(csaf.TLPLabelAmber):
 		p.badAmberRedPermissions.use()
 		// It is an error if we downloaded the advisory with
 		// an unauthorized client.


### PR DESCRIPTION
Bug: We used string comparison to rank tlp levels in the rolie label checker.

`case label >= csaf.TLPLabelAmber:` with label = `csaf.TLPLabelWhite`

is the same as `case "WHITE" > "AMBER":` which is obviously not intended.

Fix: Use the `tlpLevel` function on the labels before the comparison.