### PR TITLE
Add info for Req 8-10 if direct url was given and as such no checks were performed.

### DIFF
--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -343,12 +343,17 @@ func (p *processor) domainChecks(domain string) []func(*processor, string) error
 	} else {
 		p.badSecurity.use()
 		p.badSecurity.info(
-			"Performed no test of security.txt since the direct url of the provider-metadata.json was used.")
+			"Performed no test of security.txt " +
+				"since the direct url of the provider-metadata.json was used.")
 		p.badWellknownMetadata.use()
 		p.badWellknownMetadata.info(
-			"Performed no test on whether the provider-metadata.json is available under the .well-known path since the direct url of the provider-metadata.json was used.")
+			"Performed no test on whether the provider-metadata.json is available " +
+				"under the .well-known path " +
+				"since the direct url of the provider-metadata.json was used.")
 		p.badDNSPath.use()
-		p.badDNSPath.info("Performed no test on the contents of https://csaf.data.security.DOMAIN since direct url of provider-metadata.json was used.")
+		p.badDNSPath.info(
+			"Performed no test on the contents of https://csaf.data.security.DOMAIN " +
+				"since the direct url of the provider-metadata.json was used.")
 	}
 
 	checks = append(checks,


### PR DESCRIPTION
Solves https://github.com/csaf-poc/csaf_distribution/issues/339.

Decided to explicitly give out info both requirements as well as requirement 10 (which also checks the PMD) to make sure to differentiate this case from cases where no check was performed due to misc. reasons. 