### PR TITLE
No longer set timestamp of version as part of go version in prepareUbuntuInstanceForITests

### DIFF
--- a/docs/scripts/prepareUbuntuInstanceForITests.sh
+++ b/docs/scripts/prepareUbuntuInstanceForITests.sh
@@ -9,7 +9,7 @@ apt update
 apt install -y make bash curl gnupg sed tar git nginx fcgiwrap gnutls-bin
 
 # Install Go from binary distribution
-latest_go="$(curl https://go.dev/VERSION\?m=text).linux-amd64.tar.gz"
+latest_go="$(curl https://go.dev/VERSION\?m=text| head -1).linux-amd64.tar.gz"
 curl -O https://dl.google.com/go/$latest_go
 rm -rf /usr/local/go # be sure that we do not have an old installation
 tar -C /usr/local -xzf $latest_go


### PR DESCRIPTION
Currently, trying to set up a blank Ubuntu 20.4 Instance via prepare prepareUbuntuInstanceForITests.sh will fail since 

curl https://go.dev/VERSION\?m=text currently returns 

go1.21.0
time 2023-08-04T20:14:06Z

The timestamp setting the latest_go variable to an unusable state, causing the depending curl instance to throw a syntax error.

This PR will exclude the timestamp and allows fetching the correct go version.