### PR TITLE
Checker: Fix checking of missing files

### DIFF
--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -24,7 +24,6 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1117,7 +1116,7 @@ func (p *processor) checkMissing(string) error {
 		v := p.alreadyChecked[f]
 		var where []string
 		// mistake contains which requirements are broken
-		var mistake []string
+		mistake := util.Set[whereType]{}
 		for mask := rolieMask; mask <= listingMask; mask <<= 1 {
 			if maxMask&mask == mask {
 				var in string
@@ -1126,22 +1125,22 @@ func (p *processor) checkMissing(string) error {
 				} else {
 					in = "not in"
 					// Which file is missing entries?
-					mistake = append(mistake, mask.String())
+					mistake.Add(mask)
 				}
 				where = append(where, in+" "+mask.String())
 			}
 		}
 		// List error in all appropriate categories
-		if slices.Contains(mistake, "ROLIE") {
+		if mistake.Contains(rolieMask) {
 			p.badROLIEFeed.error("%s %s", f, strings.Join(where, ", "))
 		}
-		if slices.Contains(mistake, "index.txt") {
+		if mistake.Contains(indexMask) {
 			p.badIndices.error("%s %s", f, strings.Join(where, ", "))
 		}
-		if slices.Contains(mistake, "changes.csv") {
+		if mistake.Contains(changesMask) {
 			p.badChanges.error("%s %s", f, strings.Join(where, ", "))
 		}
-		if slices.Contains(mistake, "directory listing") {
+		if mistake.Contains(listingMask) {
 			p.badDirListings.error("%s %s", f, strings.Join(where, ", "))
 		}
 		// reset mistake

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -1116,7 +1116,7 @@ func (p *processor) checkMissing(string) error {
 		v := p.alreadyChecked[f]
 		var where []string
 		// mistake contains which requirements are broken
-		mistake := util.Set[whereType]{}
+		var mistake whereType
 		for mask := rolieMask; mask <= listingMask; mask <<= 1 {
 			if maxMask&mask == mask {
 				var in string
@@ -1125,26 +1125,29 @@ func (p *processor) checkMissing(string) error {
 				} else {
 					in = "not in"
 					// Which file is missing entries?
-					mistake.Add(mask)
+					mistake |= mask
 				}
 				where = append(where, in+" "+mask.String())
 			}
 		}
 		// List error in all appropriate categories
-		if mistake.Contains(rolieMask) {
+		if mistake&rolieMask != 0 {
 			p.badROLIEFeed.error("%s %s", f, strings.Join(where, ", "))
 		}
-		if mistake.Contains(indexMask) {
+		if mistake&indexMask != 0 {
 			p.badIndices.error("%s %s", f, strings.Join(where, ", "))
 		}
-		if mistake.Contains(changesMask) {
+		if mistake&changesMask != 0 {
 			p.badChanges.error("%s %s", f, strings.Join(where, ", "))
 		}
-		if mistake.Contains(listingMask) {
+		if mistake&listingMask != 0 {
 			p.badDirListings.error("%s %s", f, strings.Join(where, ", "))
 		}
 		// reset mistake
-		mistake = nil
+		mistake &= rolieMask
+		mistake &= indexMask
+		mistake &= changesMask
+		mistake &= listingMask
 	}
 	return nil
 }

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -1131,18 +1131,19 @@ func (p *processor) checkMissing(string) error {
 			}
 		}
 		// List error in all appropriate categories
-		if mistake&rolieMask != 0 {
-			p.badROLIEFeed.error("%s %s", f, strings.Join(where, ", "))
+		if mistake&(rolieMask|indexMask|changesMask|listingMask) == 0 {
+			continue
 		}
-		if mistake&indexMask != 0 {
-			p.badIndices.error("%s %s", f, strings.Join(where, ", "))
+		joined := strings.Join(where, ", ")
+		report := func(mask whereType, msgs *topicMessages) {
+			if mistake&mask != 0 {
+				msgs.error("%s %s", f, joined)
+			}
 		}
-		if mistake&changesMask != 0 {
-			p.badChanges.error("%s %s", f, strings.Join(where, ", "))
-		}
-		if mistake&listingMask != 0 {
-			p.badDirListings.error("%s %s", f, strings.Join(where, ", "))
-		}
+		report(rolieMask, &p.badROLIEFeed)
+		report(indexMask, &p.badIndices)
+		report(changesMask, &p.badChanges)
+		report(listingMask, &p.badDirListings)
 	}
 	return nil
 }

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -1143,11 +1143,6 @@ func (p *processor) checkMissing(string) error {
 		if mistake&listingMask != 0 {
 			p.badDirListings.error("%s %s", f, strings.Join(where, ", "))
 		}
-		// reset mistake
-		mistake &= rolieMask
-		mistake &= indexMask
-		mistake &= changesMask
-		mistake &= listingMask
 	}
 	return nil
 }


### PR DESCRIPTION
Part of https://github.com/csaf-poc/csaf_distribution/issues/438

Currently, any file discrepancies between the different file retrieval methods is reported in integrity.
This PR changes the checker so it reports any file missing from a list in their respective retrieval methods Requirement