### PR TITLE
Change release action to use elder Ubuntu runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   releases-matrix:
     name: Release Go binaries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
  * use `ubuntu-20.04` so we get binaries that are more compatible with elder GNU/Linux distribution, because go binaries link to glibc (for some operating system operations like dns).

resolve #456