### PR TITLE
Downloader: unit test forwarder

### DIFF
--- a/cmd/csaf_downloader/forwarder.go
+++ b/cmd/csaf_downloader/forwarder.go
@@ -226,6 +226,19 @@ func (f *forwarder) storeFailed(filename, doc, sha256, sha512 string) {
 	}
 }
 
+// limitedString reads max bytes from reader and returns it as a string.
+// Longer strings are indicated by "..." as a suffix.
+func limitedString(r io.Reader, max int) (string, error) {
+	var msg strings.Builder
+	if _, err := io.Copy(&msg, io.LimitReader(r, int64(max))); err != nil {
+		return "", err
+	}
+	if msg.Len() >= max {
+		msg.WriteString("...")
+	}
+	return msg.String(), nil
+}
+
 // forward sends a given document with filename, status and
 // checksums to the forwarder. This is async to the degree
 // till the configured queue size is filled.
@@ -252,16 +265,15 @@ func (f *forwarder) forward(
 		}
 		if res.StatusCode != http.StatusCreated {
 			defer res.Body.Close()
-			var msg strings.Builder
-			io.Copy(&msg, io.LimitReader(res.Body, 512))
-			var dots string
-			if msg.Len() >= 512 {
-				dots = "..."
+			if msg, err := limitedString(res.Body, 512); err != nil {
+				slog.Error("reading forward result failed",
+					"error", err)
+			} else {
+				slog.Error("forwarding failed",
+					"filename", filename,
+					"body", msg,
+					"status_code", res.StatusCode)
 			}
-			slog.Error("forwarding failed",
-				"filename", filename,
-				"body", msg.String()+dots,
-				"status_code", res.StatusCode)
 			f.storeFailed(filename, doc, sha256, sha512)
 		} else {
 			f.succeeded++

--- a/cmd/csaf_downloader/forwarder.go
+++ b/cmd/csaf_downloader/forwarder.go
@@ -187,16 +187,10 @@ func (f *forwarder) buildRequest(
 // storeFailedAdvisory stores an advisory in a special folder
 // in case the forwarding failed.
 func (f *forwarder) storeFailedAdvisory(filename, doc, sha256, sha512 string) error {
-	dir := filepath.Join(f.cfg.Directory, failedForwardDir)
 	// Create special folder if it does not exist.
-	if _, err := os.Stat(dir); err != nil {
-		if os.IsNotExist(err) {
-			if err := os.MkdirAll(dir, 0755); err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
+	dir := filepath.Join(f.cfg.Directory, failedForwardDir)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
 	}
 	// Store parts which are not empty.
 	for _, x := range []struct {

--- a/cmd/csaf_downloader/forwarder_test.go
+++ b/cmd/csaf_downloader/forwarder_test.go
@@ -13,7 +13,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"log/slog"
+	"net/http"
 	"testing"
+
+	"github.com/csaf-poc/csaf_distribution/v3/internal/options"
 )
 
 func TestValidationStatusUpdate(t *testing.T) {
@@ -80,5 +83,19 @@ func TestForwarderLogStats(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("Cannot find forward statistics in log")
+	}
+}
+
+func TestForwarderHTTPClient(t *testing.T) {
+	cfg := &config{
+		ForwardInsecure: true,
+		ForwardHeader: http.Header{
+			"User-Agent": []string{"curl/7.55.1"},
+		},
+		LogLevel: &options.LogLevel{Level: slog.LevelDebug},
+	}
+	fw := newForwarder(cfg)
+	if c1, c2 := fw.httpClient(), fw.httpClient(); c1 != c2 {
+		t.Fatal("expected to return same client twice")
 	}
 }

--- a/cmd/csaf_downloader/forwarder_test.go
+++ b/cmd/csaf_downloader/forwarder_test.go
@@ -244,10 +244,7 @@ func TestStoreFailedAdvisory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		os.Chmod(dir, 0700)
-		os.RemoveAll(dir)
-	}()
+	defer os.RemoveAll(dir)
 
 	cfg := &config{Directory: dir}
 	fw := newForwarder(cfg)
@@ -280,4 +277,7 @@ func TestStoreFailedAdvisory(t *testing.T) {
 		t.Fatal("expected to fail with an error")
 	}
 
+	if err := os.Chmod(sha256Path, 644); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/cmd/csaf_downloader/forwarder_test.go
+++ b/cmd/csaf_downloader/forwarder_test.go
@@ -379,7 +379,7 @@ func TestForwarderForward(t *testing.T) {
 	orig := slog.Default()
 	defer slog.SetDefault(orig)
 
-	// We dont care in details here as we captured the details
+	// We dont care in details here as we captured them
 	// in the other test cases.
 	h := slog.NewJSONHandler(io.Discard, nil)
 	lg := slog.New(h)

--- a/cmd/csaf_downloader/forwarder_test.go
+++ b/cmd/csaf_downloader/forwarder_test.go
@@ -99,3 +99,16 @@ func TestForwarderHTTPClient(t *testing.T) {
 		t.Fatal("expected to return same client twice")
 	}
 }
+
+func TestForwarderReplaceExtension(t *testing.T) {
+	for _, x := range [][2]string{
+		{"foo", "foo.ext"},
+		{"foo.bar", "foo.ext"},
+		{".bar", ".ext"},
+		{"", ".ext"},
+	} {
+		if got := replaceExt(x[0], ".ext"); got != x[1] {
+			t.Fatalf("got %q expected %q", got, x[1])
+		}
+	}
+}

--- a/cmd/csaf_downloader/forwarder_test.go
+++ b/cmd/csaf_downloader/forwarder_test.go
@@ -1,0 +1,26 @@
+// This file is Free Software under the MIT License
+// without warranty, see README.md and LICENSES/MIT.txt for details.
+//
+// SPDX-License-Identifier: MIT
+//
+// SPDX-FileCopyrightText: 2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2023 Intevation GmbH <https://intevation.de>
+
+package main
+
+import "testing"
+
+func TestValidationStatusUpdate(t *testing.T) {
+	sv := validValidationStatus
+	sv.update(invalidValidationStatus)
+	sv.update(validValidationStatus)
+	if sv != invalidValidationStatus {
+		t.Fatalf("got %q expected %q", sv, invalidValidationStatus)
+	}
+	sv = notValidatedValidationStatus
+	sv.update(validValidationStatus)
+	sv.update(notValidatedValidationStatus)
+	if sv != notValidatedValidationStatus {
+		t.Fatalf("got %q expected %q", sv, notValidatedValidationStatus)
+	}
+}

--- a/cmd/csaf_downloader/forwarder_test.go
+++ b/cmd/csaf_downloader/forwarder_test.go
@@ -8,7 +8,13 @@
 
 package main
 
-import "testing"
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+)
 
 func TestValidationStatusUpdate(t *testing.T) {
 	sv := validValidationStatus
@@ -22,5 +28,57 @@ func TestValidationStatusUpdate(t *testing.T) {
 	sv.update(notValidatedValidationStatus)
 	if sv != notValidatedValidationStatus {
 		t.Fatalf("got %q expected %q", sv, notValidatedValidationStatus)
+	}
+}
+
+func TestForwarderLogStats(t *testing.T) {
+	orig := slog.Default()
+	defer slog.SetDefault(orig)
+
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})
+	lg := slog.New(h)
+	slog.SetDefault(lg)
+
+	cfg := &config{}
+	fw := newForwarder(cfg)
+	fw.failed = 11
+	fw.succeeded = 13
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fw.run()
+	}()
+	fw.log()
+	fw.close()
+	<-done
+
+	type fwStats struct {
+		Msg       string `json:"msg"`
+		Succeeded int    `json:"succeeded"`
+		Failed    int    `json:"failed"`
+	}
+	sc := bufio.NewScanner(bytes.NewReader(buf.Bytes()))
+	found := false
+	for sc.Scan() {
+		var fws fwStats
+		if err := json.Unmarshal(sc.Bytes(), &fws); err != nil {
+			t.Fatalf("JSON parsing log failed: %v", err)
+		}
+		if fws.Msg == "Forward statistics" &&
+			fws.Failed == 11 &&
+			fws.Succeeded == 13 {
+			found = true
+			break
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scanning log failed: %v", err)
+	}
+	if !found {
+		t.Fatal("Cannot find forward statistics in log")
 	}
 }


### PR DESCRIPTION
Bring coverage of forwarder near 100%.

The remaining untested error paths belong to the fact that
we build the requests to the remote server in memory
with no limitations. In the future we may limit this but we
should do this earlier in the pipeline.