### PR TITLE
fix: improve logging for downloader and aggregator

### DIFF
--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -12,6 +12,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"runtime"
@@ -166,14 +167,21 @@ func (c *config) tooOldForInterims() func(time.Time) bool {
 // is in the accepted download interval of the provider or
 // the global config.
 func (p *provider) ageAccept(c *config) func(time.Time) bool {
+	var r *models.TimeRange
 	switch {
 	case p.Range != nil:
-		return p.Range.Contains
+		r = p.Range
 	case c.Range != nil:
-		return c.Range.Contains
+		r = c.Range
 	default:
 		return nil
 	}
+
+	if c.Verbose {
+		s, _ := r.MarshalJSON()
+		log.Printf("Setting up filter to accept docs within TimeRange %s", s)
+	}
+	return r.Contains
 }
 
 // ignoreFile returns true if the given URL should not be downloaded.

--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -178,8 +178,9 @@ func (p *provider) ageAccept(c *config) func(time.Time) bool {
 	}
 
 	if c.Verbose {
-		s, _ := r.MarshalJSON()
-		log.Printf("Setting up filter to accept docs within TimeRange %s", s)
+		log.Printf(
+			"Setting up filter to accept advisories within time range %s to %s\n",
+			r[0].Format(time.RFC3339), r[1].Format(time.RFC3339))
 	}
 	return r.Contains
 }

--- a/cmd/csaf_downloader/config.go
+++ b/cmd/csaf_downloader/config.go
@@ -214,7 +214,7 @@ func (cfg *config) prepareLogging() error {
 		if err != nil {
 			return err
 		}
-		log.Printf("using %q for logging\n", *cfg.LogFile)
+		log.Printf("using %q for logging\n", fname)
 		w = f
 	}
 	ho := slog.HandlerOptions{

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -204,8 +204,8 @@ func (d *downloader) download(ctx context.Context, domain string) error {
 
 	// Do we need time range based filtering?
 	if d.cfg.Range != nil {
-		slog.Debug("Setting up filter to accept documents within",
-			"TimeRange", d.cfg.Range)
+		slog.Debug("Setting up filter to accept advisories within",
+			"timerange", d.cfg.Range)
 		afp.AgeAccept = d.cfg.Range.Contains
 	}
 

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -204,6 +204,8 @@ func (d *downloader) download(ctx context.Context, domain string) error {
 
 	// Do we need time range based filtering?
 	if d.cfg.Range != nil {
+		slog.Debug("Setting up filter to accept documents within",
+			"TimeRange", d.cfg.Range)
 		afp.AgeAccept = d.cfg.Range.Contains
 	}
 


### PR DESCRIPTION
 * use full name for printing out the used logfile for the downloader.
 * for debug or verbose, log the timeintervall that will be used for downloader and aggregator. (The checker has this as part of its output already.)