### PR TITLE
docs: improve timerange documentation

### DIFF
--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -109,7 +109,7 @@ client_cert             // path to client certificate to access access-protected
 client_key              // path to client key to access access-protected advisories
 client_passphrase       // optional client cert passphrase (limited, experimental, see downloader doc)
 header                  // adds extra HTTP header fields to the client
-timerange               // Accepted time range of advisories to handle. See checker doc for details.
+timerange               // Accepted time range of advisories to handle. See downloader docs for details.
 ```
 
 Next we have two TOML _tables_:

--- a/docs/csaf_checker.md
+++ b/docs/csaf_checker.md
@@ -69,35 +69,10 @@ type 2: error
 
 The checker result is a success if no checks resulted in type 2, and a failure otherwise.
 
-The option `timerange` allows to only check advisories from a given time interval.
-It is only allowed to specify one off them. 
-There are following variants:
+The option `timerange` allows to only check advisories from a given time
+interval. It can only be given once.  See the
+[downloader documentation](csaf_downloader.md#timerange-option) for details.
 
-1. Relative. If the given string follows the rules of being a [Go duration](https://pkg.go.dev/time@go1.20.6#ParseDuration)
-    the time interval from now minus that duration till now is used. 
-    E.g. `"3h"` means checking the advisories that have changed in the last three hours.
-
-2. Absolute. If the given string is an RFC 3339 date timestamp the time interval between
-   this date and now is used. 
-   E.g. `"2006-01-02"` means that all files between 2006 January 2nd and now going to be
-   checked. 
-   Accepted patterns are:
-   - `"2006-01-02T15:04:05Z"`
-   - `"2006-01-02T15:04:05+07:00"`
-   - `"2006-01-02T15:04:05-07:00"`
-   - `"2006-01-02T15:04:05"`
-   - `"2006-01-02T15:04"`
-   - `"2006-01-02T15"`
-   - `"2006-01-02"`
-   - `"2006-01"`
-   - `"2006"`
-
-   Missing parts are set to the smallest value possible in that field.
-
-3. Range. Same as 2 but separated by a `,` to span an interval. e.g `2019,2024`
-   spans an interval from 1st January 2019 to the 1st January of 2024.
-
-All interval boundaries are inclusive.
 
 You can ignore certain advisories while checking by specifying a list
 of regular expressions[^1] to match their URLs by using the `ignorepattern`

--- a/docs/csaf_downloader.md
+++ b/docs/csaf_downloader.md
@@ -79,17 +79,39 @@ forward_queue       = 5
 forward_insecure    = false
 ```
 
+If the `folder` option is given all the advisories are stored in a subfolder
+of this name. Otherwise the advisories are each stored in a folder named
+by the year they are from.
+
+You can ignore certain advisories while downloading by specifying a list
+of regular expressions[^1] to match their URLs by using the `ignorepattern`
+option.
+
+E.g. `-i='.*white.*' -i='*.red.*'` will ignore files which URLs contain
+the sub strings **white** or **red**.
+In the config file this has to be noted as:
+```
+ignorepattern = [".*white.*", ".*red.*"]
+```
+
+#### Timerange option
+
 The `timerange` parameter enables downloading advisories which last changes falls
 into a given intervall. There are three possible notations:
 
-1. Relative. If the given string follows the rules of being a [Go duration](https://pkg.go.dev/time@go1.20.6#ParseDuration)
-    the time interval from now minus that duration till now is used. 
-    E.g. `"3h"` means downloading the advisories that have changed in the last three hours.
+1. Relative. If the given string follows the rules of a
+   [Go duration](https://pkg.go.dev/time@go1.20.6#ParseDuration),
+   the time interval from now going back that duration is used.
+    Some examples:
+    - `"3h"` means downloading the advisories that have changed in the last three hours.
+    - `"60m"` .. changed within the last hour.
+    - `"72h"` .. changed within the last three days.
+    - `"8760h"` .. changed within the last 365 days.
 
-2. Absolute. If the given string is an RFC 3339 date timestamp the time interval between
-   this date and now is used. 
+2. Absolute. If the given string is an RFC 3339 date timestamp
+   the time interval between this date and now is used.
    E.g. `"2006-01-02"` means that all files between 2006 January 2nd and now going to being
-   downloaded. 
+   downloaded.
    Accepted patterns are:
    - `"2006-01-02T15:04:05Z"`
    - `"2006-01-02T15:04:05+07:00"`
@@ -107,21 +129,6 @@ into a given intervall. There are three possible notations:
    spans an interval from 1st January 2019 to the 1st January of 2024.
 
 All interval boundaries are inclusive.
-
-If the `folder` option is given all the advisories are stored in a subfolder
-of this name. Otherwise the advisories are each stored in a folder named
-by the year they are from.
-
-You can ignore certain advisories while downloading by specifying a list
-of regular expressions[^1] to match their URLs by using the `ignorepattern`
-option.
-
-E.g. `-i='.*white.*' -i='*.red.*'` will ignore files which URLs contain
-the sub strings **white** or **red**.
-In the config file this has to be noted as:
-```
-ignorepattern = [".*white.*", ".*red.*"]
-```
 
 #### Forwarding
 The downloader is able to forward downloaded advisories and their checksums,

--- a/docs/csaf_downloader.md
+++ b/docs/csaf_downloader.md
@@ -104,7 +104,7 @@ into a given intervall. There are three possible notations:
    the time interval from now going back that duration is used.
     Some examples:
     - `"3h"` means downloading the advisories that have changed in the last three hours.
-    - `"60m"` .. changed within the last hour.
+    - `"30m"` .. changed within the last thirty minutes.
     - `"72h"` .. changed within the last three days.
     - `"8760h"` .. changed within the last 365 days.
 


### PR DESCRIPTION
 * add a documentation section to the downloader docs for the timerange-option.
 * point aggregator and checker docs to the downloader section for timerange.