### PR TITLE
Time ranges: Accept days, months and years

### DIFF
--- a/docs/csaf_downloader.md
+++ b/docs/csaf_downloader.md
@@ -102,11 +102,14 @@ into a given intervall. There are three possible notations:
 1. Relative. If the given string follows the rules of a
    [Go duration](https://pkg.go.dev/time@go1.20.6#ParseDuration),
    the time interval from now going back that duration is used.
-    Some examples:
-    - `"3h"` means downloading the advisories that have changed in the last three hours.
-    - `"30m"` .. changed within the last thirty minutes.
-    - `"72h"` .. changed within the last three days.
-    - `"8760h"` .. changed within the last 365 days.
+   In extension to this the suffixes 'd' for days, 'M' for month
+   and 'y' for years are recognized. In these cases only integer
+   values are accepted without any fractions.
+   Some examples:
+   - `"3h"` means downloading the advisories that have changed in the last three hours.
+   - `"30m"`  .. changed within the last thirty minutes.
+   - `"3M2m"` .. changed within the last three months and two minutes.
+   - `"2y"`   .. changed within the last two years.
 
 2. Absolute. If the given string is an RFC 3339 date timestamp
    the time interval between this date and now is used.

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -9,6 +9,7 @@
 package models
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -22,6 +23,36 @@ func TestNewTimeInterval(t *testing.T) {
 	)
 	if NewTimeInterval(after, before) != pseudoTimeRange {
 		t.Errorf("Failure: Couldn't generate timerange.")
+	}
+}
+
+func TestParseDuration(t *testing.T) {
+
+	now := time.Now()
+
+	for _, x := range []struct {
+		in        string
+		expected  time.Duration
+		reference time.Time
+		fail      bool
+	}{
+		{"1h", time.Hour, now, false},
+		{"2y", now.Sub(now.AddDate(-2, 0, 0)), now, false},
+		{"13M", now.Sub(now.AddDate(0, -13, 0)), now, false},
+		{"31d", now.Sub(now.AddDate(0, 0, -31)), now, false},
+		{"1h2d3m", now.Sub(now.AddDate(0, 0, -2)) + time.Hour + 3*time.Minute, now, false},
+		{strings.Repeat("1", 70) + "y1d", 0, now, true},
+	} {
+		got, err := parseDuration(x.in, x.reference)
+		if err != nil {
+			if !x.fail {
+				t.Errorf("%q should not fail: %v", x.in, err)
+			}
+			continue
+		}
+		if got != x.expected {
+			t.Errorf("%q got %v expected %v", x.in, got, x.expected)
+		}
 	}
 }
 


### PR DESCRIPTION
Solves #480 .. at least integer values for years, days and month. The fractional cases like `1.5y` are omitted as they are more complex.