### PR TITLE
API: Fix pattern matching of purls and document categories in advisory model

### DIFF
--- a/csaf/advisory.go
+++ b/csaf/advisory.go
@@ -106,7 +106,7 @@ var cpePattern = patternUnmarshal("^(cpe:2\\.3:[aho\\*\\-](:(((\\?*|\\*?)([a-zA-
 // PURL represents a package URL in an advisory.
 type PURL string
 
-var pURLPattern = patternUnmarshal(`^pkg:[A-Za-z\\.\\-\\+][A-Za-z0-9\\.\\-\\+]*/.+`)
+var pURLPattern = patternUnmarshal("^pkg:[A-Za-z\\.\\-\\+][A-Za-z0-9\\.\\-\\+]*/.+")
 
 // XGenericURI represents an identifier for a product.
 type XGenericURI struct {
@@ -223,7 +223,7 @@ type AggregateSeverity struct {
 // DocumentCategory represents a category of a document.
 type DocumentCategory string
 
-var documentCategoryPattern = patternUnmarshal(`^[^\\s\\-_\\.](.*[^\\s\\-_\\.])?$`)
+var documentCategoryPattern = patternUnmarshal("^[^\\s\\-_\\.](.*[^\\s\\-_\\.])?$")
 
 // Version is the version of a document.
 type Version string

--- a/examples/purls_searcher/main.go
+++ b/examples/purls_searcher/main.go
@@ -123,4 +123,15 @@ func (uf *urlFinder) findURLs(adv *csaf.Advisory) {
 	for _, b := range tree.Branches {
 		recBranch(b)
 	}
+
+	// Third iterate over relationships.
+	if tree.RelationShips != nil {
+		for _, rel := range *tree.RelationShips {
+			if rel != nil {
+				if fpn := rel.FullProductName; fpn != nil && fpn.ProductID != nil {
+					add(slices.Index(uf.ids, *fpn.ProductID), fpn.ProductIdentificationHelper)
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Extract purls from relationships in purls_searcher example.

Solves #486 