### PR TITLE
PMD: Support legacy security.txt location as fallback.

### DIFF
--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -1273,7 +1273,9 @@ func (p *processor) checkSecurity(domain string) string {
 		if msg == "" {
 			break
 		}
-		msgs = append(msgs, msg)
+		// Show which security.txt caused this message
+		lmsg := folder + "security.txt:" + msg
+		msgs = append(msgs, lmsg)
 	}
 	return strings.Join(msgs, "; ")
 }

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -1274,7 +1274,7 @@ func (p *processor) checkSecurity(domain string) string {
 			break
 		}
 		// Show which security.txt caused this message
-		lmsg := folder + "security.txt:" + msg
+		lmsg := folder + "security.txt: " + msg
 		msgs = append(msgs, lmsg)
 	}
 	return strings.Join(msgs, "; ")

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -1271,9 +1271,8 @@ func (p *processor) checkSecurity(domain string, legacy bool) (int, string) {
 	if msg == "" {
 		if !legacy {
 			return 0, "Found valid security.txt within the well-known directory"
-		} else {
-			return 2, "Found valid security.txt in the legacy location"
 		}
+		return 2, "Found valid security.txt in the legacy location"
 	}
 	return 1, folder + "security.txt: " + msg
 }

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -1411,6 +1411,7 @@ func (p *processor) checkWellknownSecurityDNS(domain string) error {
 	// Security check for well known (default) and legacy location
 	warningsS, sDMessage := p.checkSecurity(domain, false)
 	// if the security.txt under .well-known was not okay
+	// check for a security.txt within its legacy location
 	sLMessage := ""
 	if warningsS == 1 {
 		warningsS, sLMessage = p.checkSecurity(domain, true)

--- a/cmd/csaf_checker/reporters.go
+++ b/cmd/csaf_checker/reporters.go
@@ -251,10 +251,6 @@ func (r *securityReporter) report(p *processor, domain *Domain) {
 		req.message(WarnType, "Performed no in-depth test of security.txt.")
 		return
 	}
-	if len(p.badSecurity) == 0 {
-		req.message(InfoType, "Found CSAF entry in security.txt.")
-		return
-	}
 	req.Messages = p.badSecurity
 }
 


### PR DESCRIPTION
If we don't find the security.txt in the well-known folder try to find it under https://domain/security.txt as a fallback.

Solves #503 