### PR TITLE
Go 1.20 compat: Remove usage of slices in enum generator.

### DIFF
--- a/csaf/generate_cvss_enums.go
+++ b/csaf/generate_cvss_enums.go
@@ -17,7 +17,7 @@ import (
 	"go/format"
 	"log"
 	"os"
-	"slices"
+	"sort"
 	"strings"
 	"text/template"
 )
@@ -135,7 +135,7 @@ func main() {
 			defs = append(defs, k)
 		}
 	}
-	slices.Sort(defs)
+	sort.Strings(defs)
 
 	var source bytes.Buffer
 


### PR DESCRIPTION
In the generator to create the cvss enums  the `slices` (Go 1.21) package was used.
Replaced it with Go 1.20 compatible code.