### PR TITLE
Advisories: Time filter download by 'updated' field in ROLIE entries.

### DIFF
--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -547,7 +547,7 @@ func (p *processor) rolieFeedEntries(feed string) ([]csaf.AdvisoryFile, error) {
 
 		// Filter if we have date checking.
 		if accept := p.cfg.Range; accept != nil {
-			if pub := time.Time(entry.Updated); !pub.IsZero() && !accept.Contains(pub) {
+			if t := time.Time(entry.Updated); !t.IsZero() && !accept.Contains(t) {
 				return
 			}
 		}

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -33,7 +33,6 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/internal/models"
 	"github.com/csaf-poc/csaf_distribution/v3/util"
 )
 
@@ -548,7 +547,7 @@ func (p *processor) rolieFeedEntries(feed string) ([]csaf.AdvisoryFile, error) {
 
 		// Filter if we have date checking.
 		if accept := p.cfg.Range; accept != nil {
-			if pub := time.Time(entry.Published); !pub.IsZero() && !accept.Contains(pub) {
+			if pub := time.Time(entry.Updated); !pub.IsZero() && !accept.Contains(pub) {
 				return
 			}
 		}
@@ -667,11 +666,6 @@ func (p *processor) integrity(
 		var folderYear *int
 		if m := yearFromURL.FindStringSubmatch(u); m != nil {
 			year, _ := strconv.Atoi(m[1])
-			// Check if the year is in the accepted time interval.
-			if accept := p.cfg.Range; accept != nil &&
-				!accept.Intersects(models.Year(year)) {
-				continue
-			}
 			folderYear = &year
 		}
 

--- a/csaf/advisories.go
+++ b/csaf/advisories.go
@@ -316,7 +316,7 @@ func (afp *AdvisoryFileProcessor) processROLIE(
 
 			// Filter if we have date checking.
 			if afp.AgeAccept != nil {
-				if pub := time.Time(entry.Updated); !pub.IsZero() && !afp.AgeAccept(pub) {
+				if t := time.Time(entry.Updated); !t.IsZero() && !afp.AgeAccept(t) {
 					return
 				}
 			}

--- a/csaf/advisories.go
+++ b/csaf/advisories.go
@@ -316,7 +316,7 @@ func (afp *AdvisoryFileProcessor) processROLIE(
 
 			// Filter if we have date checking.
 			if afp.AgeAccept != nil {
-				if pub := time.Time(entry.Published); !pub.IsZero() && !afp.AgeAccept(pub) {
+				if pub := time.Time(entry.Updated); !pub.IsZero() && !afp.AgeAccept(pub) {
 					return
 				}
 			}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -31,14 +31,6 @@ func NewTimeInterval(a, b time.Time) TimeRange {
 	return TimeRange{a, b}
 }
 
-// Year returns the time range for a given year.
-func Year(year int) TimeRange {
-	return TimeRange{
-		time.Date(year, time.January, 1, 0, 0, 0, 0, time.UTC),
-		time.Date(year, time.December, 31, 23, 59, 59, int(time.Second-time.Nanosecond), time.UTC),
-	}
-}
-
 // guessDate tries to guess an RFC 3339 date time from a given string.
 func guessDate(s string) (time.Time, bool) {
 	for _, layout := range []string{

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -173,27 +173,3 @@ func TestTimeRangeIntersects(t *testing.T) {
 		}
 	}
 }
-
-// TestTimeRangeYear checks if the Year construction works.
-func TestTimeRangeYear(t *testing.T) {
-	var (
-		year   = Year(1984)
-		first  = time.Date(1984, time.January, 1, 0, 0, 0, 0, time.UTC)
-		before = first.Add(-time.Nanosecond)
-		after  = time.Date(1984+1, time.January, 1, 0, 0, 0, 0, time.UTC)
-		last   = after.Add(-time.Nanosecond)
-	)
-	for _, x := range []struct {
-		t        time.Time
-		expected bool
-	}{
-		{t: first, expected: true},
-		{t: before, expected: false},
-		{t: last, expected: true},
-		{t: after, expected: false},
-	} {
-		if got := year.Contains(x.t); got != x.expected {
-			t.Fatalf("%v: got %t expected %t", x.t, got, x.expected)
-		}
-	}
-}


### PR DESCRIPTION
Solves #518 

Now uses the `updated` field of ROLIE feed entries instead of the `published` field.

Drop time filtering in checker by folder year as this name stems from the publishing year
and not the latest update.