### PR TITLE
Fix missing error messages from loading provider-metadata.json

### DIFF
--- a/cmd/csaf_aggregator/processor.go
+++ b/cmd/csaf_aggregator/processor.go
@@ -89,17 +89,21 @@ func (w *worker) locateProviderMetadata(domain string) error {
 
 	lpmd := loader.Load(domain)
 
-	if w.processor.cfg.Verbose {
+	if !lpmd.Valid() {
 		for i := range lpmd.Messages {
-			w.log.Info(
+			w.log.Error(
 				"Loading provider-metadata.json",
 				"domain", domain,
 				"message", lpmd.Messages[i].Message)
 		}
-	}
-
-	if !lpmd.Valid() {
 		return fmt.Errorf("no valid provider-metadata.json found for '%s'", domain)
+	} else if w.processor.cfg.Verbose {
+		for i := range lpmd.Messages {
+			w.log.Debug(
+				"Loading provider-metadata.json",
+				"domain", domain,
+				"message", lpmd.Messages[i].Message)
+		}
 	}
 
 	w.metadataProvider = lpmd.Document

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -199,16 +199,19 @@ func (d *downloader) download(ctx context.Context, domain string) error {
 
 	lpmd := loader.Load(domain)
 
-	if d.cfg.verbose() {
+	if !lpmd.Valid() {
+		for i := range lpmd.Messages {
+			slog.Error("Loading provider-metadata.json",
+				"domain", domain,
+				"message", lpmd.Messages[i].Message)
+		}
+		return fmt.Errorf("no valid provider-metadata.json found for '%s': ", domain)
+	} else if d.cfg.verbose() {
 		for i := range lpmd.Messages {
 			slog.Debug("Loading provider-metadata.json",
 				"domain", domain,
 				"message", lpmd.Messages[i].Message)
 		}
-	}
-
-	if !lpmd.Valid() {
-		return fmt.Errorf("no valid provider-metadata.json found for '%s'", domain)
 	}
 
 	base, err := url.Parse(lpmd.URL)

--- a/csaf/providermetaloader.go
+++ b/csaf/providermetaloader.go
@@ -178,20 +178,7 @@ func (pmdl *ProviderMetadataLoader) Load(domain string) *LoadedProviderMetadata 
 	}
 
 	// Next load the PMDs from security.txt
-	secResults := pmdl.loadFromSecurity(domain)
-
-	// Filter out the results which are valid.
-	var secGoods []*LoadedProviderMetadata
-
-	for _, result := range secResults {
-		if len(result.Messages) > 0 {
-			// If there where validation issues append them
-			// to the overall report
-			pmdl.messages.AppendUnique(pmdl.messages)
-		} else {
-			secGoods = append(secGoods, result)
-		}
-	}
+	secGoods := pmdl.loadFromSecurity(domain)
 
 	// Mention extra CSAF entries in security.txt.
 	ignoreExtras := func() {
@@ -246,7 +233,7 @@ func (pmdl *ProviderMetadataLoader) Load(domain string) *LoadedProviderMetadata 
 	return dnsURLResult
 }
 
-// loadFromSecurity loads the PMDs mentioned in the security.txt.
+// loadFromSecurity loads the PMDs mentioned in the security.txt. Only valid PMDs are returned.
 func (pmdl *ProviderMetadataLoader) loadFromSecurity(domain string) []*LoadedProviderMetadata {
 
 	// If .well-known fails try legacy location.


### PR DESCRIPTION
## What

Fix: don't drop error messages from loading provider-metadata.json

Additionally removed the duplicate check of provider metadata candidates retrieved from `security.txt`.

## Why

Previously in case of trying last resort dns, all other error messages were dropped.