### PR TITLE
Print provider-metadata.json files per domain

### DIFF
--- a/cmd/csaf_downloader/config.go
+++ b/cmd/csaf_downloader/config.go
@@ -58,7 +58,7 @@ type config struct {
 	IgnorePattern        []string          `long:"ignore_pattern" short:"i" description:"Do not download files if their URLs match any of the given PATTERNs" value-name:"PATTERN" toml:"ignore_pattern"`
 	ExtraHeader          http.Header       `long:"header" short:"H" description:"One or more extra HTTP header fields" toml:"header"`
 
-	EnumeratePMDOnly bool `long:"enumerate_pmd_only" description:"If this flag is set to true, the donwloader will only enumerate valid provider metadata files, but not download documents" toml:"enumerate_pmd_only"`
+	EnumeratePMDOnly bool `long:"enumerate_pmd_only" description:"If this flag is set to true, the downloader will only enumerate valid provider metadata files, but not download documents" toml:"enumerate_pmd_only"`
 
 	RemoteValidator        string   `long:"validator" description:"URL to validate documents remotely" value-name:"URL" toml:"validator"`
 	RemoteValidatorCache   string   `long:"validator_cache" description:"FILE to cache remote validations" value-name:"FILE" toml:"validator_cache"`

--- a/cmd/csaf_downloader/config.go
+++ b/cmd/csaf_downloader/config.go
@@ -58,6 +58,8 @@ type config struct {
 	IgnorePattern        []string          `long:"ignore_pattern" short:"i" description:"Do not download files if their URLs match any of the given PATTERNs" value-name:"PATTERN" toml:"ignore_pattern"`
 	ExtraHeader          http.Header       `long:"header" short:"H" description:"One or more extra HTTP header fields" toml:"header"`
 
+	EnumeratePMDOnly bool `long:"enumerate_pmd_only" description:"If this flag is set to true, the donwloader will only enumerate valid provider metadata files, but not download documents" toml:"enumerate_pmd_only"`
+
 	RemoteValidator        string   `long:"validator" description:"URL to validate documents remotely" value-name:"URL" toml:"validator"`
 	RemoteValidatorCache   string   `long:"validator_cache" description:"FILE to cache remote validations" value-name:"FILE" toml:"validator_cache"`
 	RemoteValidatorPresets []string `long:"validator_preset" description:"One or more PRESETS to validate remotely" value-name:"PRESETS" toml:"validator_preset"`

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -169,8 +169,9 @@ func (d *downloader) enumerate(domain string) error {
 	client := d.httpClient()
 
 	loader := csaf.NewProviderMetadataLoader(client)
-
 	lpmd := loader.Enumerate(domain)
+
+	docs := []any{}
 
 	for _, pmd := range lpmd {
 		if d.cfg.verbose() {
@@ -181,22 +182,16 @@ func (d *downloader) enumerate(domain string) error {
 			}
 		}
 
-		if !pmd.Valid() {
-			return fmt.Errorf("invalid provider-metadata.json found for '%s'", domain)
-		}
-		_, err := url.Parse(pmd.URL)
-		if err != nil {
-			return fmt.Errorf("invalid URL found '%s': %v", pmd.URL, err)
-		}
-
-		// print the results
-		fmt.Println("Found provider-metadata file under URL", pmd.URL)
-		doc, err := json.MarshalIndent(pmd.Document, "", "  ")
-		if err != nil {
-			slog.Error("Couldn't marshal PMD document json")
-		}
-		fmt.Println(string(doc))
+		docs = append(docs, pmd.Document)
 	}
+
+	// print the results
+	doc, err := json.MarshalIndent(docs, "", "  ")
+	if err != nil {
+		slog.Error("Couldn't marshal PMD document json")
+	}
+	fmt.Println(string(doc))
+
 	return nil
 }
 

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -165,6 +165,39 @@ func httpLog(who string) func(string, string) {
 	}
 }
 
+func (d *downloader) enumerate(ctx context.Context, domain string) error {
+	client := d.httpClient()
+
+	loader := csaf.NewProviderMetadataLoader(client)
+
+	lpmd := loader.Enumerate(domain)
+
+	if d.cfg.verbose() {
+		for i := range lpmd.Messages {
+			slog.Debug("Loading provider-metadata.json",
+				"domain", domain,
+				"message", lpmd.Messages[i].Message)
+		}
+	}
+
+	for _, pmd := range lpmd {
+		if !pmd.Valid() {
+			return fmt.Errorf("invalid provider-metadata.json found for '%s'", domain)
+		}
+		_, err := url.Parse(pmd.URL)
+		if err != nil {
+			return fmt.Errorf("invalid URL found '%s': %v", pmd.URL, err)
+		}
+
+		// TODO print
+		fmt.Println(pmd.URL)
+		fmt.Println(pmd.Document)
+		fmt.Println(pmd.Messages)
+		fmt.Println(pmd.Hash)
+	}
+
+}
+
 func (d *downloader) download(ctx context.Context, domain string) error {
 	client := d.httpClient()
 

--- a/cmd/csaf_downloader/main.go
+++ b/cmd/csaf_downloader/main.go
@@ -41,6 +41,11 @@ func run(cfg *config, domains []string) error {
 		d.forwarder = f
 	}
 
+	// First, enumerate existing PMDs, then load
+	err = d.runEnumerate(domains)
+	if err != nil {
+		return err
+	}
 	return d.run(ctx, domains)
 }
 

--- a/cmd/csaf_downloader/main.go
+++ b/cmd/csaf_downloader/main.go
@@ -41,12 +41,12 @@ func run(cfg *config, domains []string) error {
 		d.forwarder = f
 	}
 
-	// First, enumerate existing PMDs, then load
-	err = d.runEnumerate(domains)
-	if err != nil {
-		return err
+	if cfg.EnumeratePMDOnly {
+		// Enumerate only
+		return d.runEnumerate(domains)
+	} else {
+		return d.run(ctx, domains)
 	}
-	return d.run(ctx, domains)
 }
 
 func main() {

--- a/cmd/csaf_downloader/main.go
+++ b/cmd/csaf_downloader/main.go
@@ -41,12 +41,12 @@ func run(cfg *config, domains []string) error {
 		d.forwarder = f
 	}
 
+	// If the enumerate-only flag is set, enumerate found PMDs,
+	// else use the normal load method
 	if cfg.EnumeratePMDOnly {
-		// Enumerate only
 		return d.runEnumerate(domains)
-	} else {
-		return d.run(ctx, domains)
 	}
+	return d.run(ctx, domains)
 }
 
 func main() {

--- a/csaf/providermetaloader.go
+++ b/csaf/providermetaloader.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -125,13 +126,13 @@ func (pmdl *ProviderMetadataLoader) Enumerate(domain string) []*LoadedProviderMe
 
 	// Validate the candidate and add to the result array
 	if wellknownResult.Valid() {
-		fmt.Println("Found well known result")
+		slog.Debug("Found well known provider-metadata.json")
 		resPMDs = append(resPMDs, wellknownResult)
 	}
 
 	// Next load the PMDs from security.txt
 	secResults := pmdl.loadFromSecurity(domain)
-	fmt.Println("Found security.txt results", len(secResults))
+	slog.Info("Found provider metadata results in security.txt", "num", len(secResults))
 
 	for _, result := range secResults {
 		if result.Valid() {

--- a/csaf/providermetaloader.go
+++ b/csaf/providermetaloader.go
@@ -109,6 +109,9 @@ func NewProviderMetadataLoader(client util.Client) *ProviderMetadataLoader {
 	}
 }
 
+// Enumerate lists all PMD files that can be found under the given domain.
+// As specified in CSAF 2.0, it looks for PMDs using the well-known URL and
+// the security.txt, and if no PMDs have been found, it also checks the DNS-URL.
 func (pmdl *ProviderMetadataLoader) Enumerate(domain string) []*LoadedProviderMetadata {
 
 	// Our array of PMDs to be found
@@ -143,10 +146,9 @@ func (pmdl *ProviderMetadataLoader) Enumerate(domain string) []*LoadedProviderMe
 	// According to the spec, only if no PMDs have been found, the should DNS URL be used
 	if len(resPMDs) > 0 {
 		return resPMDs
-	} else {
-		dnsURL := "https://csaf.data.security." + domain
-		return []*LoadedProviderMetadata{pmdl.loadFromURL(dnsURL)}
 	}
+	dnsURL := "https://csaf.data.security." + domain
+	return []*LoadedProviderMetadata{pmdl.loadFromURL(dnsURL)}
 
 }
 

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -177,7 +177,7 @@ categories document. For a more detailed explanation and examples,
 ```toml
 workers = 2
 folder = "/var/csaf_aggregator"
-lock_file = "/var/csaf_aggregator/run.lock"
+lock_file = "/var/lock/csaf_aggregator/lock"
 web = "/var/csaf_aggregator/html"
 domain = "https://localhost:9443"
 rate = 10.0
@@ -187,6 +187,7 @@ insecure = true
 #interim_years =
 #passphrase =
 #write_indices = false
+#time_range =
 
 # specification requires at least two providers (default),
 # to override for testing, enable:
@@ -208,6 +209,7 @@ insecure = true
   create_service_document = true
 #  rate = 1.5
 #  insecure = true
+#  time_range =
 
 [[providers]]
   name = "local-dev-provider2"
@@ -217,8 +219,8 @@ insecure = true
   write_indices = true
   client_cert = "./../devca1/testclient1.crt"
   client_key = "./../devca1/testclient1-key.pem"
-#  client_passphrase =
-# header =
+#  client_passphrase = # Limited and experimental, see downloader doc.
+#  header =
 
 [[providers]]
   name = "local-dev-provider3"
@@ -226,10 +228,10 @@ insecure = true
 #  rate = 1.8
 #  insecure = true
   write_indices = true
-  # If aggregator.category == "aggregator", set for an entry that should
+  # If aggregator.category == "aggreator", set for an entry that should
   # be listed in addition:
   category = "lister"
-#  ignore_pattern = [".*white.*", ".*red.*"]
+# ignore_pattern = [".*white.*", ".*red.*"]
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -100,22 +100,12 @@ The following example file documents all available configuration options:
 #tlps = ["csaf", "white", "amber", "green", "red"]
 
 # Make the provider create a ROLIE service document.
-#create_service_document = true
+#create_service_document = false
 
 # Make the provider create a ROLIE category document from a list of strings.
 # If a list item starts with `expr:`
 #   the rest of the string is used as a JsonPath expression
 #   to extract a string from the incoming advisories.
-#   If the result of the expression is a string this string
-#   is used. If the result is an array each element of
-#   this array is tested if it is a string or an array.
-#   If this test fails the expression fails. If the
-#   test succeeds the rules are applied recursively to
-#   collect all strings in the result.
-#   Suggested expressions are:
-#   - vendor, product family and product names:  "expr:$.product_tree..branches[?(@.category==\"vendor\" || @.category==\"product_family\" || @.category==\"product_name\")].name"
-#   - CVEs: "expr:$.vulnerabilities[*].cve"
-#   - CWEs: "expr:$.vulnerabilities[*].cwe.id"
 # Strings not starting with `expr:` are taken verbatim.
 # By default no category documents are created.
 # This example provides an overview over the syntax,


### PR DESCRIPTION
This PR addresses #520. It adds an enumerate method to the providermetaloader.go which loads the PMDs from the well-known path, the security.txt, or the DNS URL (as defined in the spec in [requirement 7.3.1](https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#731-finding-provider-metadatajson)).

The PR also includes usage of the new method in the csaf_downloader and its main method.

There is, however, still a doubt that I have about the issue: Why does the load method compare the PMD from the well-known path to the first one found in the security.txt? I couldn't find a respective requirement in the spec. It could be the case that a provider provides the PMD in the well-known path and only advertises additional PMDs in the security.txt, right?

Looking forward to your feedback!