### PR TITLE
update prepareUbuntuInstanceForITests.sh

### DIFF
--- a/docs/scripts/Readme.md
+++ b/docs/scripts/Readme.md
@@ -1,6 +1,7 @@
-Scripts for assisting the Integration tests. They are written on Ubuntu 20.04 TLS amd64.
+Scripts for assisting the Integration tests.
+They were written on Ubuntu 20.04 TLS amd64 and also tested with 24.04 TLS.
 
-- `prepareUbunutForITest.sh` installs the required packages for the csaf_distribution integration tests on a naked ubuntu 20.04 LTS amd64.
+- `prepareUbuntuInstanceForITests.sh` installs the required packages for the csaf_distribution integration tests on a naked ubuntu LTS amd64.
 
 - `TLSConfigsForITest.sh` generates a root CA and webserver cert by running `createRootCAForITest.sh` and `createWebserverCertForITest.sh`
 and configures nginx for serving TLS connections.

--- a/docs/scripts/prepareUbuntuInstanceForITests.sh
+++ b/docs/scripts/prepareUbuntuInstanceForITests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-# This script prepares a naked Ubuntu 20.04 LTS amd64
+# This script prepares a naked Ubuntu LTS amd64
 # for the csaf_distribution integration tests
 # by installing the required packages.
 
@@ -14,19 +14,17 @@ curl -O https://dl.google.com/go/$latest_go
 rm -rf /usr/local/go # be sure that we do not have an old installation
 tar -C /usr/local -xzf $latest_go
 
-# Install newer Node.js version from nodesource
+# Install a current Node.js version from nodesource
 # as needed for https://github.com/secvisogram/csaf-validator-service
 # Instructions from
 #  https://github.com/nodesource/distributions/blob/master/README.md#debmanual
 KEYRING=/usr/share/keyrings/nodesource.gpg
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor > "$KEYRING"
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor > "$KEYRING"
 gpg --no-default-keyring --keyring "$KEYRING" --list-keys
 chmod a+r /usr/share/keyrings/nodesource.gpg
 
-VERSION=node_16.x
-DISTRO="$(lsb_release -s -c)"
-echo "deb [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO main" | tee /etc/apt/sources.list.d/nodesource.list
-echo "deb-src [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list
+NODE_MAJOR=20
+echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 
 apt-get update
 apt-get install -y nodejs


### PR DESCRIPTION
 * to handle a newer nodejs
 * mention that Ubuntu 24.04 TLS was tested as well.