### PR TITLE
docs: fix licensing info for generated files

### DIFF
--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,11 @@
+Copyright (c) <year> <owner>. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/csaf/cvss20enums.go
+++ b/csaf/cvss20enums.go
@@ -1,10 +1,5 @@
-// This file is Free Software under the Apache-2.0 License
-// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
-//
-// SPDX-License-Identifier: Apache-2.0
-//
-// SPDX-FileCopyrightText: 2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
-// Software-Engineering: 2023 Intevation GmbH <https://intevation.de>
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: 2017 FIRST.ORG, INC.
 //
 // THIS FILE IS MACHINE GENERATED. EDIT WITH CARE!
 

--- a/csaf/cvss3enums.go
+++ b/csaf/cvss3enums.go
@@ -1,10 +1,5 @@
-// This file is Free Software under the Apache-2.0 License
-// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
-//
-// SPDX-License-Identifier: Apache-2.0
-//
-// SPDX-FileCopyrightText: 2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
-// Software-Engineering: 2023 Intevation GmbH <https://intevation.de>
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: 2017 FIRST.ORG, INC.
 //
 // THIS FILE IS MACHINE GENERATED. EDIT WITH CARE!
 

--- a/csaf/generate_cvss_enums.go
+++ b/csaf/generate_cvss_enums.go
@@ -22,13 +22,11 @@ import (
 	"text/template"
 )
 
-const tmplText = `// This file is Free Software under the MIT License
-// without warranty, see README.md and LICENSES/MIT.txt for details.
-//
-// SPDX-License-Identifier: MIT
-//
-// SPDX-FileCopyrightText: 2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
-// Software-Engineering: 2023 Intevation GmbH <https://intevation.de>
+// We from Intevation consider the source code parts in the following
+// template file as too insignificant to be a piece of work that gains
+// "copyrights" protection in the European Union. So the license(s)
+// of the output files are fully determined by the input file.
+const tmplText = `// determine license(s) from input file and replace this line
 //
 // THIS FILE IS MACHINE GENERATED. EDIT WITH CARE!
 

--- a/csaf/schema/cvss-v2.0.json.license
+++ b/csaf/schema/cvss-v2.0.json.license
@@ -1,0 +1,2 @@
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-FileCopyrightText: 2017 FIRST.ORG, INC.

--- a/csaf/schema/cvss-v3.0.json.license
+++ b/csaf/schema/cvss-v3.0.json.license
@@ -1,0 +1,2 @@
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-FileCopyrightText: 2017 FIRST.ORG, INC.

--- a/csaf/schema/cvss-v3.1.json.license
+++ b/csaf/schema/cvss-v3.1.json.license
@@ -1,0 +1,2 @@
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-FileCopyrightText: 2021 FIRST.ORG, INC.


### PR DESCRIPTION
 * change generate_cvss_enums.go to note that the input file is relevant for the license.
 * change license and copyright of cvss20enums.go and cvss3enums.go to BSD-3-Clause and FIRST.
 * add reuse.software 3.0 compatible files for the schema cvss files.

resolves #534 