### PR TITLE
[README.md] Enhance linking and grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 # csaf_distribution
 
 Implements a [CSAF](https://csaf.io/)
-([Specification v2.0](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html))
+([Specification v2.0](https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html) and its [errata](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html))
 trusted provider, checker, aggregator and downloader.
 Includes an uploader command line tool for the trusted provider.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 # csaf_distribution
 
-Implementations of a [CSAF](https://csaf.io/)
+Implements a [CSAF](https://csaf.io/)
 ([Specification v2.0](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html))
 trusted provider, checker, aggregator and downloader.
 Includes an uploader command line tool for the trusted provider.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@
 # csaf_distribution
 
 An implementation of a [CSAF](https://csaf.io/)
-[2.0 Spec](https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html)
-([Errata](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html))
+([Specification v2.0](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html))
 trusted provider, checker, aggregator and downloader.
 Includes an uploader command line tool for the trusted provider.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 # csaf_distribution
 
 Implements a [CSAF](https://csaf.io/)
-([Specification v2.0](https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html) and its [errata](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html))
+([specification v2.0](https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html)
+and its [errata](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html))
 trusted provider, checker, aggregator and downloader.
 Includes an uploader command line tool for the trusted provider.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 # csaf_distribution
 
-An implementation of a [CSAF](https://csaf.io/)
+Implementations of a [CSAF](https://csaf.io/)
 ([Specification v2.0](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html))
 trusted provider, checker, aggregator and downloader.
 Includes an uploader command line tool for the trusted provider.


### PR DESCRIPTION
- Fix grammar and enhance wording.
- Consecutive web-links without non-linked, non-whitespace characters are … problematic; thus rectified.
- References to outdated specifications do not make much sense, hence omitted, especially as the link to the current specification immediately followed.