### PR TITLE
fix error message in csaf downloader

### DIFF
--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -205,7 +205,7 @@ func (d *downloader) download(ctx context.Context, domain string) error {
 				"domain", domain,
 				"message", lpmd.Messages[i].Message)
 		}
-		return fmt.Errorf("no valid provider-metadata.json found for '%s': ", domain)
+		return fmt.Errorf("no valid provider-metadata.json found for '%s'", domain)
 	} else if d.cfg.verbose() {
 		for i := range lpmd.Messages {
 			slog.Debug("Loading provider-metadata.json",


### PR DESCRIPTION
## What

Minor fix of the error message returned on an invalid provider metadata json in the csaf downloader.

## Why

The error message had a trailing `:` which suggest that there are some details which were truncated. However the details are already printed before in the log.

The extra `:` was accidentally added in #531 