### PR TITLE
feat: no longer require to be root user to call setup scripts

### DIFF
--- a/docs/scripts/Readme.md
+++ b/docs/scripts/Readme.md
@@ -12,10 +12,10 @@ and configures nginx for serving TLS connections.
 
 As creating the folders needs to authenticate with the csaf_provider, the configurations of TLS server and Client certificate authentication should be set. So it is recommended to call the scripts in this order: `TLSConfigsForITest.sh`, `TLSClientConfigsForITest.sh`, `setupProviderForITest.sh`
 
-Calling example (as root):
+Calling example (as user with sudo privileges):
 ``` bash
     curl --fail -O https://raw.githubusercontent.com/csaf-poc/csaf_distribution/main/docs/scripts/prepareUbuntuInstanceForITests.sh
-    bash prepareUbuntuInstanceForITests.sh
+    sudo bash prepareUbuntuInstanceForITests.sh
 
     git clone https://github.com/csaf-poc/csaf_distribution.git # --branch <name>
     pushd csaf_distribution/docs/scripts/

--- a/docs/scripts/setupValidationService.sh
+++ b/docs/scripts/setupValidationService.sh
@@ -21,7 +21,7 @@ echo '
 remote_validator= { "url" = "http://localhost:8082", "presets" = ["mandatory"], "cache" = "/var/lib/csaf/validations.db" }
 ' | sudo tee --append /etc/csaf/config.toml
 
-npm install pm2 -g
+sudo npm install pm2 -g
 
 pushd ~
 git clone https://github.com/secvisogram/csaf-validator-service.git


### PR DESCRIPTION
Currently you need to be root to use the setupscripts as described. This will allow users with sudo privileges to use the setup scripts as well.