### PR TITLE
Fix(Setup Scripts): add sudo to commands that would fail due to missing permissions when running as nonroot user

### DIFF
--- a/docs/scripts/TLSClientConfigsForITest.sh
+++ b/docs/scripts/TLSClientConfigsForITest.sh
@@ -36,7 +36,7 @@ echo '
                 return 403;
             }
         }
-'> ~/${FOLDERNAME}/clientCertificateConfigs.txt
+'  | sudo tee ~/${FOLDERNAME}/clientCertificateConfigs.txt
 
 sudo sed -i "/^server {/r  ${HOME}/${FOLDERNAME}/clientCertificateConfigs.txt" $NGINX_CONFIG_PATH
 

--- a/docs/scripts/TLSConfigsForITest.sh
+++ b/docs/scripts/TLSConfigsForITest.sh
@@ -33,14 +33,14 @@ echo '
         ssl_certificate_key '${SSL_CERTIFICATE_KEY}'; # e.g. ssl_certificate_key /etc/ssl/csaf/testserver-key.pem;
 
         ssl_protocols TLSv1.2 TLSv1.3;
-' > ~/${FOLDERNAME}/TLSConfigs.txt
+'  | sudo tee ~/${FOLDERNAME}/TLSConfigs.txt
 
 # a second listener port for testing setup where someone wants to tunnel access
 # to an unpriviledged port and still have the same access url
 echo '
         listen 8443 ssl default_server; # ipv4
         listen [::]:8443 ssl http2 default_server;  # ipv6
-' > ~/${FOLDERNAME}/TLS8443Configs.txt
+'  | sudo tee ~/${FOLDERNAME}/TLS8443Configs.txt
 
 sudo cp $NGINX_CONFIG_PATH $NGINX_CONFIG_PATH.org
 sudo sed -i "/^server {/r ${HOME}/${FOLDERNAME}/TLSConfigs.txt" $NGINX_CONFIG_PATH

--- a/docs/scripts/createCCForITest.sh
+++ b/docs/scripts/createCCForITest.sh
@@ -11,10 +11,10 @@
 
 set -e
 
-mkdir -p ~/${FOLDERNAME}
+sudo mkdir -p ~/${FOLDERNAME}
 cd ~/${FOLDERNAME}
 
-certtool --generate-privkey --outfile testclient1-key.pem
+sudo certtool --generate-privkey --outfile testclient1-key.pem
 
 echo '
 organization = "'${ORGANAME}'"
@@ -27,13 +27,13 @@ encryption_key
 
 serial = 020
 expiration_days = 50
-' > gnutls-certtool.testclient1.template
+'  | sudo tee gnutls-certtool.testclient1.template
 
-certtool --generate-certificate --load-privkey testclient1-key.pem --outfile testclient1.crt --load-ca-certificate rootca-cert.pem --load-ca-privkey rootca-key.pem --template gnutls-certtool.testclient1.template --stdout | head -1
+sudo certtool --generate-certificate --load-privkey testclient1-key.pem --outfile testclient1.crt --load-ca-certificate rootca-cert.pem --load-ca-privkey rootca-key.pem --template gnutls-certtool.testclient1.template --stdout | head -1
 
-certtool --load-ca-certificate rootca-cert.pem --load-certificate testclient1.crt --load-privkey testclient1-key.pem --to-p12 --p12-name "Test Client 1" --null-password --outder --outfile testclient1.p12
+sudo certtool --load-ca-certificate rootca-cert.pem --load-certificate testclient1.crt --load-privkey testclient1-key.pem --to-p12 --p12-name "Test Client 1" --null-password --outder --outfile testclient1.p12
 
-certtool --generate-privkey --outfile testclient2-key.pem
+sudo certtool --generate-privkey --outfile testclient2-key.pem
 
 echo '
 organization = "'${ORGANAME}'"
@@ -46,11 +46,11 @@ encryption_key
 
 serial = 021
 expiration_days = 1
-' > gnutls-certtool.testclient2.template
+' sudo tee gnutls-certtool.testclient2.template
 
-certtool --generate-certificate --load-privkey testclient2-key.pem --outfile testclient2.crt --load-ca-certificate rootca-cert.pem --load-ca-privkey rootca-key.pem --template gnutls-certtool.testclient2.template --stdout | head -1
+sudo certtool --generate-certificate --load-privkey testclient2-key.pem --outfile testclient2.crt --load-ca-certificate rootca-cert.pem --load-ca-privkey rootca-key.pem --template gnutls-certtool.testclient2.template --stdout | head -1
 
-certtool --load-ca-certificate rootca-cert.pem --load-certificate testclient2.crt --load-privkey testclient2-key.pem --to-p12 --p12-name "Test Client 2" --null-password --outder --outfile testclient2.p12
+sudo certtool --load-ca-certificate rootca-cert.pem --load-certificate testclient2.crt --load-privkey testclient2-key.pem --to-p12 --p12-name "Test Client 2" --null-password --outder --outfile testclient2.p12
 
 SSL_CLIENT_CERTIFICATE=$(
 echo "$PWD/rootca-cert.pem"

--- a/docs/scripts/createCCForITest.sh
+++ b/docs/scripts/createCCForITest.sh
@@ -46,7 +46,7 @@ encryption_key
 
 serial = 021
 expiration_days = 1
-' sudo tee gnutls-certtool.testclient2.template
+' | sudo tee gnutls-certtool.testclient2.template
 
 sudo certtool --generate-certificate --load-privkey testclient2-key.pem --outfile testclient2.crt --load-ca-certificate rootca-cert.pem --load-ca-privkey rootca-key.pem --template gnutls-certtool.testclient2.template --stdout | head -1
 

--- a/docs/scripts/createRootCAForITest.sh
+++ b/docs/scripts/createRootCAForITest.sh
@@ -26,6 +26,6 @@ crl_signing_key
 
 serial = 001
 expiration_days = 100
-' sudo tee gnutls-certtool.rootca.template
+' | sudo tee gnutls-certtool.rootca.template
 
 sudo certtool --generate-self-signed --load-privkey rootca-key.pem --outfile rootca-cert.pem --template gnutls-certtool.rootca.template --stdout | head -1

--- a/docs/scripts/createRootCAForITest.sh
+++ b/docs/scripts/createRootCAForITest.sh
@@ -10,10 +10,10 @@
 
 set -e
 
-mkdir -p ~/${FOLDERNAME}
+sudo mkdir -p ~/${FOLDERNAME}
 cd ~/${FOLDERNAME}
 
-certtool --generate-privkey --outfile rootca-key.pem
+sudo certtool --generate-privkey --outfile rootca-key.pem
 
 echo '
 organization = "'${ORGANAME}'"
@@ -26,6 +26,6 @@ crl_signing_key
 
 serial = 001
 expiration_days = 100
-' >gnutls-certtool.rootca.template
+' sudo tee gnutls-certtool.rootca.template
 
-certtool --generate-self-signed --load-privkey rootca-key.pem --outfile rootca-cert.pem --template gnutls-certtool.rootca.template --stdout | head -1
+sudo certtool --generate-self-signed --load-privkey rootca-key.pem --outfile rootca-cert.pem --template gnutls-certtool.rootca.template --stdout | head -1

--- a/docs/scripts/createWebserverCertForITest.sh
+++ b/docs/scripts/createWebserverCertForITest.sh
@@ -10,7 +10,7 @@ set -e
 
 pushd ~/${FOLDERNAME}
 
-certtool --generate-privkey --outfile testserver-key.pem
+sudo certtool --generate-privkey --outfile testserver-key.pem
 
 echo '
 organization = "'${ORGANAME}'"
@@ -27,11 +27,11 @@ dns_name = "localhost"
 
 serial = 010
 expiration_days = 50
-' > gnutls-certtool.testserver.template
+' sudo tee gnutls-certtool.testserver.template
 
-certtool --generate-certificate --load-privkey testserver-key.pem --outfile testserver.crt --load-ca-certificate rootca-cert.pem --load-ca-privkey rootca-key.pem --template gnutls-certtool.testserver.template --stdout | head -1
+sudo certtool --generate-certificate --load-privkey testserver-key.pem --outfile testserver.crt --load-ca-certificate rootca-cert.pem --load-ca-privkey rootca-key.pem --template gnutls-certtool.testserver.template --stdout | head -1
 
-cat testserver.crt rootca-cert.pem >bundle.crt
+cat testserver.crt rootca-cert.pem | sudo tee bundle.crt
 
 export SSL_CERTIFICATE=$(
 echo "$PWD/bundle.crt"

--- a/docs/scripts/createWebserverCertForITest.sh
+++ b/docs/scripts/createWebserverCertForITest.sh
@@ -27,7 +27,7 @@ dns_name = "localhost"
 
 serial = 010
 expiration_days = 50
-' sudo tee gnutls-certtool.testserver.template
+' | sudo tee gnutls-certtool.testserver.template
 
 sudo certtool --generate-certificate --load-privkey testserver-key.pem --outfile testserver.crt --load-ca-certificate rootca-cert.pem --load-ca-privkey rootca-key.pem --template gnutls-certtool.testserver.template --stdout | head -1
 

--- a/docs/scripts/testChecker.sh
+++ b/docs/scripts/testChecker.sh
@@ -13,7 +13,7 @@ set -e  # to exit if a command in the script fails
 echo '==== run checker (twice)'
 cd ~/csaf_distribution
 
-./bin-linux-amd64/csaf_checker -f html -o ../checker-results.html --insecure \
+sudo ./bin-linux-amd64/csaf_checker -f html -o ../checker-results.html --insecure \
   --client_cert ~/devca1/testclient1.crt \
   --client_key ~/devca1/testclient1-key.pem \
   --verbose --insecure localhost

--- a/docs/scripts/uploadToProvider.sh
+++ b/docs/scripts/uploadToProvider.sh
@@ -20,7 +20,7 @@ set -e
 TLPs=("white" "green" "amber" "red")
 COUNTER=0
 for f in $(ls csaf_examples); do
-    ../../bin-linux-amd64/csaf_uploader --insecure -P security123 -a upload \
+    sudo ../../bin-linux-amd64/csaf_uploader --insecure -P security123 -a upload \
         -t ${TLPs[$((COUNTER++ % 4))]} \
         -u https://localhost:8443/cgi-bin/csaf_provider.go \
         --client_cert ~/devca1/testclient1.crt \


### PR DESCRIPTION
https://github.com/csaf-poc/csaf_distribution/pull/552 is not working properly. The scripts no longer fail, but a lot of the test setup isn't set up properly due to missing permissions.  This should fix it.