### PR TITLE
Improve PGP fingerprint handling

### DIFF
--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -1449,7 +1449,7 @@ func (p *processor) checkWellknownSecurityDNS(domain string) error {
 }
 
 // checkPGPKeys checks if the OpenPGP keys are available and valid, fetches
-// the the remotely keys and compares the fingerprints.
+// the remotely keys and compares the fingerprints.
 // As a result of these a respective error messages are passed to badPGP method
 // in case of errors. It returns nil if all checks are passed.
 func (p *processor) checkPGPKeys(_ string) error {
@@ -1518,8 +1518,13 @@ func (p *processor) checkPGPKeys(_ string) error {
 			continue
 		}
 
+		if key.Fingerprint == "" {
+			p.badPGPs.warn("No fingerprint for public OpenPGP key found.")
+			continue
+		}
+
 		if !strings.EqualFold(ckey.GetFingerprint(), string(key.Fingerprint)) {
-			p.badPGPs.error("Fingerprint of public OpenPGP key %s does not match remotely loaded.", u)
+			p.badPGPs.error("Given Fingerprint (%q) of public OpenPGP key %q does not match remotely loaded (%q).", string(key.Fingerprint), u, ckey.GetFingerprint())
 			continue
 		}
 		if p.keys == nil {

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -1518,11 +1518,6 @@ func (p *processor) checkPGPKeys(_ string) error {
 			continue
 		}
 
-		if key.Fingerprint == "" {
-			p.badPGPs.warn("No fingerprint for public OpenPGP key found.")
-			continue
-		}
-
 		if !strings.EqualFold(ckey.GetFingerprint(), string(key.Fingerprint)) {
 			p.badPGPs.error("Given Fingerprint (%q) of public OpenPGP key %q does not match remotely loaded (%q).", string(key.Fingerprint), u, ckey.GetFingerprint())
 			continue

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -1449,9 +1449,9 @@ func (p *processor) checkWellknownSecurityDNS(domain string) error {
 }
 
 // checkPGPKeys checks if the OpenPGP keys are available and valid, fetches
-// the remotely keys and compares the fingerprints.
-// As a result of these a respective error messages are passed to badPGP method
-// in case of errors. It returns nil if all checks are passed.
+// the remote pubkeys and compares the fingerprints.
+// As a result of these checks respective error messages are passed
+// to badPGP methods. It returns nil if all checks are passed.
 func (p *processor) checkPGPKeys(_ string) error {
 
 	p.badPGPs.use()

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -366,11 +366,6 @@ func (d *downloader) loadOpenPGPKeys(
 			continue
 		}
 
-		if key.Fingerprint == "" {
-			slog.Warn("No fingerprint for public OpenPGP key found.")
-			continue
-		}
-
 		if !strings.EqualFold(ckey.GetFingerprint(), string(key.Fingerprint)) {
 			slog.Warn(
 				"Fingerprint of public OpenPGP key does not match remotely loaded",

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -366,10 +366,15 @@ func (d *downloader) loadOpenPGPKeys(
 			continue
 		}
 
+		if key.Fingerprint == "" {
+			slog.Warn("No fingerprint for public OpenPGP key found.")
+			continue
+		}
+
 		if !strings.EqualFold(ckey.GetFingerprint(), string(key.Fingerprint)) {
 			slog.Warn(
 				"Fingerprint of public OpenPGP key does not match remotely loaded",
-				"url", u)
+				"url", u, "fingerprint", key.Fingerprint, "remote-fingerprint", ckey.GetFingerprint())
 			continue
 		}
 		if d.keys == nil {


### PR DESCRIPTION
Warn if no fingerprint is specified and give more details if fingerprint comparison fails. This pull request does not change the API and cannot differentiate if an empty or no fingerprint is provided.