### PR TITLE
Use .test TLD for integration setup

### DIFF
--- a/docs/development-ca.md
+++ b/docs/development-ca.md
@@ -55,7 +55,7 @@ signing_key
 encryption_key
 non_repudiation
 
-dns_name = "*.local"
+dns_name = "*.test"
 dns_name = "localhost"
 
 serial = 010

--- a/docs/scripts/setupProviderForITest.sh
+++ b/docs/scripts/setupProviderForITest.sh
@@ -17,7 +17,7 @@ sudo chgrp -R www-data  /var/www
 sudo chmod -R g+ws  /var/www
 
 export NGINX_CONFIG_PATH=/etc/nginx/sites-available/default
-export DNS_NAME=csaf.data.security.localhost
+export DNS_NAME=csaf.data.security.test
 
 sudo cp /usr/share/doc/fcgiwrap/examples/nginx.conf /etc/nginx/fcgiwrap.conf
 


### PR DESCRIPTION
`.local` is reserved for local-area networks, and `.localhost` is reserved for loopback devices. Using `.test` allows easier usage for different test setups.