### PR TITLE
fix incorrect usage of formatted string

### DIFF
--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -81,7 +81,7 @@ func TestUnmarshalText(t *testing.T) {
 	byteSlice := []byte{'3', 'h'}
 	var emptySlice []byte
 	if testTimeRange.UnmarshalText(byteSlice) != nil {
-		t.Errorf(testTimeRange.UnmarshalText(byteSlice).Error())
+		t.Error(testTimeRange.UnmarshalText(byteSlice).Error())
 	}
 	if testTimeRange.UnmarshalText(emptySlice) == nil {
 		t.Errorf("Failure: UnmarshalText succeeded on invalid slice of bytes.")
@@ -104,10 +104,10 @@ func TestUnmarshalFlag(t *testing.T) {
 		time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC))
 	if err := testTimeRange.UnmarshalFlag("3h"); err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	if err := testTimeRange.UnmarshalFlag("2006-01-02T15:04:05"); err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	if err := testTimeRange.UnmarshalFlag("2006-01-02T15:04:05a"); err == nil {
 		t.Errorf("Failure: Extracted time from invalid string")
@@ -119,7 +119,7 @@ func TestUnmarshalFlag(t *testing.T) {
 		t.Errorf("Failure: Extracted time from invalid string")
 	}
 	if err := testTimeRange.UnmarshalFlag("2006-01-02T15:04:05, 2007-01-02T15:04:05"); err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 }
 

--- a/internal/options/options_test.go
+++ b/internal/options/options_test.go
@@ -90,7 +90,7 @@ func TestParse(t *testing.T) {
 	cmd.Env = append(os.Environ(), "TEST_HELP=1")
 	err := cmd.Run()
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	// test the version flag
@@ -104,7 +104,7 @@ func TestParse(t *testing.T) {
 	cmd.Env = append(os.Environ(), "TEST_VERSION=1")
 	err = cmd.Run()
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 }
 
@@ -140,7 +140,7 @@ func TestLoadToml(t *testing.T) {
 		t.Errorf("Failure: Succeeded in parsing nonexistant parameter")
 	}
 	if err := loadTOML(&cfg, "data/config.toml"); err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 }
 


### PR DESCRIPTION
## What

fix incorrect usage of formatted string

Output probably unchanged, but now `go vet` is happy that formatted strings are not misused.

## Why

Go vet is a mandatory check and with the updated go version is has more findings: [Go 1.24.0 Changelog](https://tip.golang.org/doc/go1.24#vet). 

Issue which will occur when go version is updated to at least `1.24.0` in the `go.mod` file in the future.