### PR TITLE
fix: engine is invalid when name is missing

### DIFF
--- a/csaf/advisory.go
+++ b/csaf/advisory.go
@@ -891,8 +891,8 @@ func (rs Revisions) Validate() error {
 
 // Validate validates an Engine.
 func (e *Engine) Validate() error {
-	if e.Version == nil {
-		return errors.New("'version' is missing")
+	if e.Name == nil {
+		return errors.New("'name' is missing")
 	}
 	return nil
 }

--- a/csaf/advisory_test.go
+++ b/csaf/advisory_test.go
@@ -14,11 +14,12 @@ func TestLoadAdvisory(t *testing.T) {
 		name    string
 		args    args
 		wantErr bool
-	}{{
-		name:    "Valid documents",
-		args:    args{jsonDir: "csaf-documents/valid"},
-		wantErr: false,
-	},
+	}{
+		{
+			name:    "Valid documents",
+			args:    args{jsonDir: "csaf-documents/valid"},
+			wantErr: false,
+		},
 		{
 			name:    "Garbage trailing data",
 			args:    args{jsonDir: "csaf-documents/trailing-garbage-data"},

--- a/testdata/csaf-documents/valid/advisory-tracking-generator-no-version.json
+++ b/testdata/csaf-documents/valid/advisory-tracking-generator-no-version.json
@@ -1,0 +1,169 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/v1/"
+      }
+    },
+    "notes": [
+      {
+        "category": "summary",
+        "title": "Test document summary",
+        "text": "Auto generated test CSAF document"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "ACME Inc.",
+      "namespace": "https://www.example.com"
+    },
+    "title": "Test CSAF document",
+    "tracking": {
+      "current_release_date": "2020-01-01T00:00:00Z",
+      "generator": {
+        "date": "2020-01-01T00:00:00Z",
+        "engine": {
+          "name": "csaf-tool"
+        }
+      },
+      "id": "Avendor-advisory-0004",
+      "initial_release_date": "2020-01-01T00:00:00Z",
+      "revision_history": [
+        {
+          "date": "2020-01-01T00:00:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "AVendor",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "product_1",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "1.1",
+                "product": {
+                  "name": "AVendor product_1 1.1",
+                  "product_id": "CSAFPID_0001"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "1.2",
+                "product": {
+                  "name": "AVendor product_1 1.2",
+                  "product_id": "CSAFPID_0002"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "2.0",
+                "product": {
+                  "name": "AVendor product_1 2.0",
+                  "product_id": "CSAFPID_0003"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "category": "vendor",
+        "name": "AVendor1",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "product_2",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "1",
+                "product": {
+                  "name": "AVendor1 product_2 1",
+                  "product_id": "CSAFPID_0004"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "category": "vendor",
+        "name": "AVendor",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "product_3",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "2022H2",
+                "product": {
+                  "name": "AVendor product_3 2022H2",
+                  "product_id": "CSAFPID_0005"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2020-1234",
+      "notes": [
+        {
+          "category": "description",
+          "title": "CVE description",
+          "text": "https://nvd.nist.gov/vuln/detail/CVE-2020-1234"
+        }
+      ],
+      "product_status": {
+        "under_investigation": ["CSAFPID_0001"]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Customers should upgrade to the latest version of the product",
+          "date": "2020-01-01T00:00:00Z",
+          "product_ids": ["CSAFPID_0001"]
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2020-9876",
+      "notes": [
+        {
+          "category": "description",
+          "title": "CVE description",
+          "text": "https://nvd.nist.gov/vuln/detail/CVE-2020-9876"
+        }
+      ],
+      "product_status": {
+        "under_investigation": ["CSAFPID_0001"]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Still under investigation",
+          "date": "2020-01-01T00:00:00Z",
+          "product_ids": ["CSAFPID_0001"]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hello 👋 , this PR fixes https://github.com/gocsaf/csaf/issues/709

According to the [specification](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf_json_schema.json), the validation of the `tracking.generator.engine` should check the name is not nil rather than the version which is optional. This is what the PR changes.
