### PR TITLE
#734 feat(csaf_uploader): add optional signing via system gpg/gpg-agent

### DIFF
--- a/cmd/csaf_uploader/config.go
+++ b/cmd/csaf_uploader/config.go
@@ -23,9 +23,10 @@ import (
 )
 
 const (
-	defaultURL    = "https://localhost/cgi-bin/csaf_provider.go"
-	defaultAction = "upload"
-	defaultTLP    = "csaf"
+	defaultURL       = "https://localhost/cgi-bin/csaf_provider.go"
+	defaultAction    = "upload"
+	defaultTLP       = "csaf"
+	defaultGPGBinary = "gpg"
 )
 
 // The supported flag config of the uploader command line
@@ -37,6 +38,10 @@ type config struct {
 	TLP            string `short:"t" long:"tlp" choice:"csaf" choice:"white" choice:"green" choice:"amber" choice:"red" description:"TLP of the feed" toml:"tlp"`
 	ExternalSigned bool   `short:"x" long:"external_signed" description:"CSAF files are signed externally. Assumes .asc files beside CSAF files." toml:"external_signed"`
 	NoSchemaCheck  bool   `short:"s" long:"no_schema_check" description:"Do not check files against CSAF JSON schema locally." toml:"no_schema_check"`
+
+	GPG       bool    `long:"gpg" description:"Sign CSAF files via the system gpg binary (delegates passphrase/PIN to gpg-agent)" toml:"gpg"`
+	GPGUser   *string `long:"gpg-user" description:"Signing key identity for gpg --local-user (fingerprint/email/keyid)" value-name:"IDENTITY" toml:"gpg_user"`
+	GPGBinary string  `long:"gpg-binary" description:"Path to the gpg executable" value-name:"GPG-BIN" toml:"gpg_binary"`
 
 	Key              *string `short:"k" long:"key" description:"OpenPGP key to sign the CSAF files" value-name:"KEY-FILE" toml:"key"`
 	Password         *string `short:"p" long:"password" description:"Authentication password for accessing the CSAF provider" value-name:"PASSWORD" toml:"password"`
@@ -55,7 +60,7 @@ type config struct {
 
 	clientCerts []tls.Certificate
 	cachedAuth  string
-	keyRing     *crypto.KeyRing
+	signer      signer
 }
 
 // iniPaths are the potential file locations of the the config file.
@@ -76,6 +81,7 @@ func parseArgsConfig() ([]string, *config, error) {
 			cfg.URL = defaultURL
 			cfg.Action = defaultAction
 			cfg.TLP = defaultTLP
+			cfg.GPGBinary = defaultGPGBinary
 		},
 		// Re-establish default values if not set.
 		EnsureDefaults: func(cfg *config) {
@@ -87,6 +93,9 @@ func parseArgsConfig() ([]string, *config, error) {
 			}
 			if cfg.TLP == "" {
 				cfg.TLP = defaultTLP
+			}
+			if cfg.GPGBinary == "" {
+				cfg.GPGBinary = defaultGPGBinary
 			}
 		},
 	}
@@ -141,25 +150,66 @@ func loadOpenPGPKey(filename string) (*crypto.Key, error) {
 	return crypto.NewKeyFromArmoredReader(f)
 }
 
-// prepareOpenPGPKey loads the configured OpenPGP key.
-func (cfg *config) prepareOpenPGPKey() error {
-	if cfg.Action != "upload" || cfg.Key == nil {
-		return nil
-	}
-	if cfg.ExternalSigned {
-		return errors.New("refused to sign external signed files")
-	}
-	key, err := loadOpenPGPKey(*cfg.Key)
+// loadKeyRing loads an OpenPGP key from a file and, if a passphrase is given,
+// unlocks it, returning a key ring ready for in-process signing. A nil
+// passphrase leaves the key as loaded: usable if the key is not protected, and
+// failing later at sign time if it is.
+func loadKeyRing(filename string, passphrase *string) (*crypto.KeyRing, error) {
+	key, err := loadOpenPGPKey(filename)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if cfg.Passphrase != nil {
-		if key, err = key.Unlock([]byte(*cfg.Passphrase)); err != nil {
-			return err
+	if passphrase != nil {
+		if key, err = key.Unlock([]byte(*passphrase)); err != nil {
+			return nil, err
 		}
 	}
-	cfg.keyRing, err = crypto.NewKeyRing(key)
-	return err
+	return crypto.NewKeyRing(key)
+}
+
+// prepareSigning validates the signing related flags and instantiates the
+// signer for the selected mode. The three signing modes (system gpg binary,
+// file key and external signed) are mutually exclusive. It is the single entry
+// point for signing setup: the no-sign and external-signed modes leave
+// cfg.signer nil.
+func (cfg *config) prepareSigning() error {
+	// The three signing modes are mutually exclusive, and neither in-process
+	// mode may be combined with externally signed files. These are validated
+	// regardless of action, before any signer is constructed.
+	if cfg.GPG && cfg.Key != nil {
+		return errors.New("--gpg and --key are mutually exclusive")
+	}
+	if cfg.GPG && cfg.ExternalSigned {
+		return errors.New("--gpg and --external_signed are mutually exclusive")
+	}
+	if cfg.Key != nil && cfg.ExternalSigned {
+		return errors.New("--key and --external_signed are mutually exclusive")
+	}
+	if !cfg.GPG && cfg.GPGUser != nil {
+		return errors.New("--gpg-user is only valid in combination with --gpg")
+	}
+
+	// A signer is only needed when uploading; other actions leave it nil.
+	if cfg.Action != "upload" {
+		return nil
+	}
+
+	switch {
+	case cfg.GPG:
+		localUser := ""
+		if cfg.GPGUser != nil {
+			localUser = *cfg.GPGUser
+		}
+		cfg.signer = &gpgSigner{binary: cfg.GPGBinary, localUser: localUser}
+
+	case cfg.Key != nil:
+		keyRing, err := loadKeyRing(*cfg.Key, cfg.Passphrase)
+		if err != nil {
+			return err
+		}
+		cfg.signer = &keyRingSigner{keyRing: keyRing}
+	}
+	return nil
 }
 
 // preparePassword pre-calculates the auth header.
@@ -180,7 +230,7 @@ func (cfg *config) prepare() error {
 	for _, prepare := range []func(*config) error{
 		(*config).prepareCertificates,
 		(*config).prepareInteractive,
-		(*config).prepareOpenPGPKey,
+		(*config).prepareSigning,
 		(*config).preparePassword,
 	} {
 		if err := prepare(cfg); err != nil {

--- a/cmd/csaf_uploader/config_test.go
+++ b/cmd/csaf_uploader/config_test.go
@@ -1,0 +1,114 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+
+package main
+
+import "testing"
+
+// TestPrepareSigningMutualExclusion covers acceptance criteria 2 and 3: the
+// system-gpg mode is mutually exclusive with the file-key and external-signed
+// modes, each producing its specific error, while --gpg on its own is accepted.
+func TestPrepareSigningMutualExclusion(t *testing.T) {
+	key := "some-key-file"
+	user := "0xDEADBEEF"
+
+	tests := []struct {
+		name    string
+		cfg     config
+		wantErr string
+	}{
+		{
+			name: "gpg and key are mutually exclusive",
+			cfg: config{
+				GPG: true,
+				Key: &key,
+			},
+			wantErr: "--gpg and --key are mutually exclusive",
+		},
+		{
+			name: "gpg and external_signed are mutually exclusive",
+			cfg: config{
+				GPG:            true,
+				ExternalSigned: true,
+			},
+			wantErr: "--gpg and --external_signed are mutually exclusive",
+		},
+		{
+			name: "key and external_signed are mutually exclusive",
+			cfg: config{
+				Key:            &key,
+				ExternalSigned: true,
+			},
+			wantErr: "--key and --external_signed are mutually exclusive",
+		},
+		{
+			name: "gpg alone is accepted",
+			cfg: config{
+				GPG: true,
+			},
+		},
+		{
+			name: "gpg with gpg-user and gpg-binary is accepted",
+			cfg: config{
+				GPG:       true,
+				GPGUser:   &user,
+				GPGBinary: "gpg",
+			},
+		},
+		{
+			name: "key alone is accepted (no gpg)",
+			cfg: config{
+				Key: &key,
+			},
+		},
+		{
+			name: "external_signed alone is accepted (no gpg)",
+			cfg: config{
+				ExternalSigned: true,
+			},
+		},
+		{
+			name: "gpg-user without gpg is rejected",
+			cfg: config{
+				GPGUser: &user,
+			},
+			wantErr: "--gpg-user is only valid in combination with --gpg",
+		},
+		{
+			name: "no signing flags is accepted",
+			cfg:  config{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.cfg
+			err := cfg.prepareSigning()
+			switch {
+			case tt.wantErr == "" && err != nil:
+				t.Fatalf("prepareSigning() returned unexpected error: %v", err)
+			case tt.wantErr != "" && err == nil:
+				t.Fatalf("prepareSigning() = nil, want error %q", tt.wantErr)
+			case tt.wantErr != "" && err.Error() != tt.wantErr:
+				t.Fatalf("prepareSigning() error = %q, want %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestPrepareSigningGPGModeInstallsSigner confirms that gpg mode installs a
+// gpgSigner without touching the file-key loading path.
+func TestPrepareSigningGPGModeInstallsSigner(t *testing.T) {
+	cfg := config{GPG: true, Action: "upload"}
+	if err := cfg.prepareSigning(); err != nil {
+		t.Fatalf("prepareSigning() in gpg mode returned error: %v", err)
+	}
+	if _, ok := cfg.signer.(*gpgSigner); !ok {
+		t.Fatalf("prepareSigning() gpg mode signer = %T, want *gpgSigner", cfg.signer)
+	}
+}

--- a/cmd/csaf_uploader/gpg_integration_test.go
+++ b/cmd/csaf_uploader/gpg_integration_test.go
@@ -1,0 +1,146 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/ProtonMail/gopenpgp/v2/crypto"
+)
+
+// TestGPGSignerRealGPGWireCompatibility is the optional, gated integration test
+// for acceptance criterion 10's verification half: a signature produced by the
+// real gpg binary via gpgSigner must verify against the uploaded bytes using
+// the same gopenpgp path the csaf_provider server uses
+// (NewPGPSignatureFromArmored + VerifyDetached). It is fully hermetic: a
+// throwaway key is created in an ephemeral GNUPGHOME under a temp dir and no
+// network is used. The test skips cleanly when gpg is unavailable.
+func TestGPGSignerRealGPGWireCompatibility(t *testing.T) {
+	gpgBin, err := exec.LookPath("gpg")
+	if err != nil {
+		t.Skip("gpg binary not available; skipping real-gpg integration test")
+	}
+
+	// gpg-agent creates a UNIX socket inside GNUPGHOME; its full path must stay
+	// under the ~108-byte sockaddr_un limit. The default deeply-nested
+	// t.TempDir() path can exceed that, so create a short home under the system
+	// temp dir and register cleanup ourselves.
+	gnupgHome, err := os.MkdirTemp("", "csaf-gpg-it-")
+	if err != nil {
+		t.Fatalf("creating ephemeral GNUPGHOME: %v", err)
+	}
+	if err := os.Chmod(gnupgHome, 0o700); err != nil {
+		t.Fatalf("chmod GNUPGHOME: %v", err)
+	}
+	if len(gnupgHome) > 80 {
+		t.Skipf("GNUPGHOME path too long for gpg-agent sockets (%d bytes): %s", len(gnupgHome), gnupgHome)
+	}
+
+	// Extra environment entries pointing gpg at the ephemeral home. They are
+	// appended to the inherited environment both by the helper commands (via
+	// env) and by the production gpgSigner (via its env field).
+	gpgEnv := []string{
+		"GNUPGHOME=" + gnupgHome,
+		// Keep gpg fully non-interactive and offline.
+		"GPG_TTY=",
+	}
+	env := append(os.Environ(), gpgEnv...)
+
+	// Stop the agent and remove the home after the test (LIFO: kill first).
+	t.Cleanup(func() { os.RemoveAll(gnupgHome) })
+	t.Cleanup(func() { killAgent(t, gpgBin, gnupgHome, env) })
+
+	// Generate a throwaway, passphrase-less RSA key in the ephemeral home.
+	genKey(t, gpgBin, gnupgHome, env)
+
+	// Export the public key so we can verify with gopenpgp.
+	pubArmored := exportPublicKey(t, gpgBin, gnupgHome, env)
+	pubKey, err := crypto.NewKeyFromArmored(pubArmored)
+	if err != nil {
+		t.Fatalf("parsing exported public key: %v", err)
+	}
+	verifyRing, err := crypto.NewKeyRing(pubKey)
+	if err != nil {
+		t.Fatalf("building verify key ring: %v", err)
+	}
+
+	// Sign via gpgSigner with GNUPGHOME pointed at the ephemeral home.
+	doc := []byte(`{"document":{"title":"integration"}}`)
+
+	s := &gpgSigner{binary: gpgBin, env: gpgEnv}
+	armored, err := s.sign(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("gpgSigner.sign with real gpg failed: %v", err)
+	}
+	if !strings.Contains(armored, "BEGIN PGP SIGNATURE") {
+		t.Fatalf("real gpg output is not an armored signature:\n%s", armored)
+	}
+
+	// Verify the detached signature exactly as the server would.
+	pgpSig, err := crypto.NewPGPSignatureFromArmored(armored)
+	if err != nil {
+		t.Fatalf("NewPGPSignatureFromArmored: %v", err)
+	}
+	if err := verifyRing.VerifyDetached(
+		crypto.NewPlainMessage(doc), pgpSig, crypto.GetUnixTime(),
+	); err != nil {
+		t.Fatalf("VerifyDetached on real-gpg signature failed: %v", err)
+	}
+}
+
+func genKey(t *testing.T, gpgBin, home string, env []string) {
+	t.Helper()
+	batch := strings.Join([]string{
+		"%no-protection",
+		"Key-Type: RSA",
+		"Key-Length: 2048",
+		"Subkey-Type: RSA",
+		"Subkey-Length: 2048",
+		"Name-Real: CSAF Integration Tester",
+		"Name-Email: integration@example.com",
+		"Expire-Date: 0",
+		"%commit",
+	}, "\n")
+
+	cmd := exec.Command(gpgBin, "--batch", "--gen-key", "--pinentry-mode", "loopback")
+	cmd.Env = env
+	cmd.Stdin = strings.NewReader(batch)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("could not generate throwaway gpg key (environment unsuitable): %v\n%s", err, out)
+	}
+	_ = home
+}
+
+func exportPublicKey(t *testing.T, gpgBin, home string, env []string) string {
+	t.Helper()
+	cmd := exec.Command(gpgBin, "--batch", "--armor", "--export", "integration@example.com")
+	cmd.Env = env
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("exporting public key: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatalf("exported public key is empty")
+	}
+	_ = home
+	return string(out)
+}
+
+func killAgent(t *testing.T, gpgBin, home string, env []string) {
+	t.Helper()
+	// Best-effort: stop the gpg-agent so the temp dir can be removed cleanly.
+	cmd := exec.Command("gpgconf", "--kill", "gpg-agent")
+	cmd.Env = env
+	_ = cmd.Run()
+	_, _, _ = gpgBin, home, env
+}

--- a/cmd/csaf_uploader/processor.go
+++ b/cmd/csaf_uploader/processor.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -20,10 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/ProtonMail/gopenpgp/v2/armor"
-	"github.com/ProtonMail/gopenpgp/v2/constants"
-	"github.com/ProtonMail/gopenpgp/v2/crypto"
 
 	"github.com/gocsaf/csaf/v3/csaf"
 	"github.com/gocsaf/csaf/v3/internal/misc"
@@ -107,7 +104,7 @@ func (p *processor) create() error {
 // uploadRequest creates the request for uploading a csaf document by passing the filename.
 // According to the flags values the multipart sections of the request are established.
 // It returns the created http request.
-func (p *processor) uploadRequest(filename string) (*http.Request, error) {
+func (p *processor) uploadRequest(ctx context.Context, filename string) (*http.Request, error) {
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -152,24 +149,23 @@ func (p *processor) uploadRequest(filename string) (*http.Request, error) {
 		return nil, err
 	}
 
-	if p.cfg.keyRing == nil && p.cfg.Passphrase != nil {
+	s := p.cfg.signer
+
+	if s == nil && p.cfg.Passphrase != nil {
 		if err := writer.WriteField("passphrase", *p.cfg.Passphrase); err != nil {
 			return nil, err
 		}
 	}
 
-	if p.cfg.keyRing != nil {
-		sig, err := p.cfg.keyRing.SignDetached(crypto.NewPlainMessage(data))
+	if s != nil {
+		sig, err := s.sign(ctx, data)
 		if err != nil {
 			return nil, err
 		}
-		armored, err := armor.ArmorWithTypeAndCustomHeaders(
-			sig.Data, constants.PGPSignatureHeader, "", "")
-		if err != nil {
-			return nil, err
-		}
-		if err := writer.WriteField("signature", armored); err != nil {
-			return nil, err
+		if sig != "" {
+			if err := writer.WriteField("signature", sig); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -200,13 +196,13 @@ func (p *processor) uploadRequest(filename string) (*http.Request, error) {
 
 // process attemps to upload a file to the server.
 // It prints the response messages.
-func (p *processor) process(filename string) error {
+func (p *processor) process(ctx context.Context, filename string) error {
 
 	if bn := filepath.Base(filename); !util.ConformingFileName(bn) {
 		return fmt.Errorf("%q is not a conforming file name", bn)
 	}
 
-	req, err := p.uploadRequest(filename)
+	req, err := p.uploadRequest(ctx, filename)
 	if err != nil {
 		return err
 	}
@@ -269,7 +265,9 @@ func (p *processor) run(args []string) error {
 	}
 
 	for _, arg := range args {
-		if err := p.process(arg); err != nil {
+		// The signing deadline is applied inside the gpg signer; the upload
+		// itself is not bounded by it, so a plain background context is fine.
+		if err := p.process(context.Background(), arg); err != nil {
 			return fmt.Errorf("processing %q failed: %v", arg, err)
 		}
 	}

--- a/cmd/csaf_uploader/processor_test.go
+++ b/cmd/csaf_uploader/processor_test.go
@@ -1,0 +1,287 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"mime"
+	"mime/multipart"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ProtonMail/gopenpgp/v2/crypto"
+)
+
+// buildGo compiles src into bin using the local go toolchain. It is shared by
+// the signer stub tests (signer_test.go) and is offline because the compiled
+// sources only use the standard library.
+func buildGo(t *testing.T, bin, src string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// minimalCSAF is a tiny well-formed JSON object. The multipart tests run with
+// NoSchemaCheck=true so the content does not need to be a valid CSAF advisory;
+// only the bytes-on-the-wire matter here.
+const minimalCSAF = `{"document":{"title":"test"}}`
+
+// writeCSAFFile writes a conforming-named CSAF file into a temp dir and returns
+// its path. The provider's ConformingFileName check is bypassed because the
+// tests call uploadRequest directly, but a JSON-safe name keeps things tidy.
+func writeCSAFFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing CSAF file: %v", err)
+	}
+	return p
+}
+
+// parseMultipart parses an http.Request produced by uploadRequest and returns a
+// map of field name to value for the simple (non-file) and file fields.
+func parseMultipart(t *testing.T, p *processor, filename string) map[string]string {
+	t.Helper()
+
+	req, err := p.uploadRequest(context.Background(), filename)
+	if err != nil {
+		t.Fatalf("uploadRequest() error: %v", err)
+	}
+
+	_, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+	if err != nil {
+		t.Fatalf("parsing content-type: %v", err)
+	}
+	boundary := params["boundary"]
+	if boundary == "" {
+		t.Fatalf("no multipart boundary in content-type %q", req.Header.Get("Content-Type"))
+	}
+
+	mr := multipart.NewReader(req.Body, boundary)
+	fields := map[string]string{}
+	for {
+		part, err := mr.NextPart()
+		if err != nil {
+			break
+		}
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, part); err != nil {
+			t.Fatalf("reading part %q: %v", part.FormName(), err)
+		}
+		fields[part.FormName()] = buf.String()
+	}
+	return fields
+}
+
+// newTestConfig returns a config suitable for uploadRequest unit tests:
+// schema check disabled, sensible defaults.
+func newTestConfig() *config {
+	return &config{
+		URL:           defaultURL,
+		TLP:           defaultTLP,
+		Action:        defaultAction,
+		NoSchemaCheck: true,
+	}
+}
+
+// TestUploadRequestNoSigner covers acceptance criterion 1 / disposition 1: with
+// no signer and a passphrase set, the multipart body carries a passphrase field
+// and no signature field (the pre-change baseline behavior).
+func TestUploadRequestNoSignerWithPassphrase(t *testing.T) {
+	dir := t.TempDir()
+	file := writeCSAFFile(t, dir, "doc.json", minimalCSAF)
+
+	pass := "s3cret"
+	cfg := newTestConfig()
+	cfg.Passphrase = &pass
+
+	// no key, no gpg -> nil signer (cfg.signer left unset).
+
+	fields := parseMultipart(t, &processor{cfg: cfg}, file)
+
+	if fields["csaf"] != minimalCSAF {
+		t.Errorf("csaf field = %q, want %q", fields["csaf"], minimalCSAF)
+	}
+	if fields["tlp"] != defaultTLP {
+		t.Errorf("tlp field = %q, want %q", fields["tlp"], defaultTLP)
+	}
+	if got, ok := fields["passphrase"]; !ok || got != pass {
+		t.Errorf("passphrase field = %q (present=%v), want %q present", got, ok, pass)
+	}
+	if _, ok := fields["signature"]; ok {
+		t.Errorf("signature field present, want absent in no-signer mode")
+	}
+}
+
+// TestUploadRequestKeyRingSigner covers disposition 2: a key-ring signer writes
+// a real armored detached signature into the signature field and no passphrase.
+func TestUploadRequestKeyRingSigner(t *testing.T) {
+	dir := t.TempDir()
+	file := writeCSAFFile(t, dir, "doc.json", minimalCSAF)
+
+	keyRing := newTestKeyRing(t)
+
+	pass := "ignored-when-signing"
+	cfg := newTestConfig()
+	cfg.Passphrase = &pass
+	cfg.signer = &keyRingSigner{keyRing: keyRing}
+
+	fields := parseMultipart(t, &processor{cfg: cfg}, file)
+
+	sig, ok := fields["signature"]
+	if !ok || sig == "" {
+		t.Fatalf("signature field missing/empty, want armored signature")
+	}
+	if !strings.Contains(sig, "BEGIN PGP SIGNATURE") {
+		t.Errorf("signature field is not an armored PGP signature: %q", sig)
+	}
+	if _, ok := fields["passphrase"]; ok {
+		t.Errorf("passphrase field present, want suppressed when a signer is active")
+	}
+
+	// The signature must verify against the uploaded bytes.
+	verifyDetached(t, keyRing, []byte(minimalCSAF), sig)
+}
+
+// TestUploadRequestGPGSigner covers criterion 4: the gpg signer's stdout is
+// written verbatim into the signature field and no passphrase field is written,
+// even though a passphrase is configured (it must never reach gpg mode output).
+func TestUploadRequestGPGSigner(t *testing.T) {
+	dir := t.TempDir()
+	file := writeCSAFFile(t, dir, "doc.json", minimalCSAF)
+
+	const armored = "-----BEGIN PGP SIGNATURE-----\n\nGPGSTUBOUTPUT\n-----END PGP SIGNATURE-----\n"
+
+	// Point gpg mode at the deterministic stub binary. The gpg argv/stdin
+	// contract itself is covered in signer_test.go; here we drive the real
+	// gpgSigner through uploadRequest to test multipart composition and that
+	// the uploaded bytes reach gpg's stdin.
+	bin := buildStubGPG(t)
+	stdinFile := filepath.Join(dir, "stdin")
+	t.Setenv("STUB_STDIN_FILE", stdinFile)
+	t.Setenv("STUB_STDOUT", armored)
+
+	cfg := newTestConfig()
+	pass := "must-not-appear"
+	cfg.Passphrase = &pass
+	cfg.signer = &gpgSigner{binary: bin}
+
+	fields := parseMultipart(t, &processor{cfg: cfg}, file)
+
+	if got := fields["signature"]; got != armored {
+		t.Errorf("signature field = %q, want verbatim gpg output %q", got, armored)
+	}
+	if _, ok := fields["passphrase"]; ok {
+		t.Errorf("passphrase field present, want never written in gpg/signer mode")
+	}
+	gotStdin, err := os.ReadFile(stdinFile)
+	if err != nil {
+		t.Fatalf("reading captured stdin: %v", err)
+	}
+	if string(gotStdin) != minimalCSAF {
+		t.Errorf("gpg received %q, want the uploaded bytes %q", gotStdin, minimalCSAF)
+	}
+}
+
+// TestUploadRequestExternalSigned covers disposition 3: the contents of the
+// adjacent .asc file become the signature field. External-signed mode produces
+// a nil signer, so the passphrase field follows the same guard as the no-signer
+// baseline (cfg.signer == nil && cfg.Passphrase != nil): present iff a
+// passphrase is configured. This matches the pre-feature behavior exactly, where
+// the original guard (no key ring loaded) wrote the passphrase field in
+// external-signed mode.
+func TestUploadRequestExternalSigned(t *testing.T) {
+	const asc = "-----BEGIN PGP SIGNATURE-----\n\nEXTERNALSIG\n-----END PGP SIGNATURE-----\n"
+
+	tests := []struct {
+		name          string
+		passphrase    *string
+		wantPass      bool
+		wantPassValue string
+	}{
+		{
+			name:       "without passphrase",
+			passphrase: nil,
+			wantPass:   false,
+		},
+		{
+			name:          "with passphrase",
+			passphrase:    func() *string { s := "s3cret"; return &s }(),
+			wantPass:      true,
+			wantPassValue: "s3cret",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			file := writeCSAFFile(t, dir, "doc.json", minimalCSAF)
+			if err := os.WriteFile(file+".asc", []byte(asc), 0o600); err != nil {
+				t.Fatalf("writing .asc: %v", err)
+			}
+
+			cfg := newTestConfig()
+			cfg.ExternalSigned = true
+			cfg.Passphrase = tc.passphrase
+			// external-signed => nil signer (cfg.signer left unset).
+
+			fields := parseMultipart(t, &processor{cfg: cfg}, file)
+
+			if got := fields["signature"]; got != asc {
+				t.Errorf("signature field = %q, want .asc contents %q", got, asc)
+			}
+
+			got, ok := fields["passphrase"]
+			if ok != tc.wantPass {
+				t.Errorf("passphrase field present=%v, want present=%v "+
+					"(external-signed keeps the baseline nil-signer guard)", ok, tc.wantPass)
+			}
+			if tc.wantPass && got != tc.wantPassValue {
+				t.Errorf("passphrase field = %q, want %q", got, tc.wantPassValue)
+			}
+		})
+	}
+}
+
+// --- helpers for OpenPGP key generation / verification -------------------
+
+// newTestKeyRing builds an in-memory throwaway OpenPGP key ring for signing.
+func newTestKeyRing(t *testing.T) *crypto.KeyRing {
+	t.Helper()
+	key, err := crypto.GenerateKey("csaf tester", "tester@example.com", "rsa", 2048)
+	if err != nil {
+		t.Fatalf("generating test key: %v", err)
+	}
+	ring, err := crypto.NewKeyRing(key)
+	if err != nil {
+		t.Fatalf("building key ring: %v", err)
+	}
+	return ring
+}
+
+// verifyDetached asserts that armoredSig is a valid detached signature over
+// data, using the same gopenpgp path the server uses.
+func verifyDetached(t *testing.T, ring *crypto.KeyRing, data []byte, armoredSig string) {
+	t.Helper()
+	pgpSig, err := crypto.NewPGPSignatureFromArmored(armoredSig)
+	if err != nil {
+		t.Fatalf("parsing armored signature: %v", err)
+	}
+	if err := ring.VerifyDetached(
+		crypto.NewPlainMessage(data), pgpSig, crypto.GetUnixTime(),
+	); err != nil {
+		t.Fatalf("VerifyDetached failed: %v", err)
+	}
+}

--- a/cmd/csaf_uploader/signer.go
+++ b/cmd/csaf_uploader/signer.go
@@ -1,0 +1,116 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/ProtonMail/gopenpgp/v2/armor"
+	"github.com/ProtonMail/gopenpgp/v2/constants"
+	"github.com/ProtonMail/gopenpgp/v2/crypto"
+)
+
+// gpgSignTimeout bounds the wait for the external gpg invocation, leaving
+// enough time for a human to enter a PIN via pinentry while still terminating
+// a stuck process.
+const gpgSignTimeout = 2 * time.Minute
+
+// signer produces an ASCII-armored detached OpenPGP signature over data.
+// It returns ("", nil) when no signature should be attached.
+type signer interface {
+	sign(ctx context.Context, data []byte) (string, error)
+}
+
+// keyRingSigner signs in-process using a gopenpgp key ring loaded from a file.
+type keyRingSigner struct {
+	keyRing *crypto.KeyRing
+}
+
+// sign reproduces the historic in-process signing path: a detached signature
+// over data, ASCII-armored with the OpenPGP signature header.
+func (s *keyRingSigner) sign(_ context.Context, data []byte) (string, error) {
+	sig, err := s.keyRing.SignDetached(crypto.NewPlainMessage(data))
+	if err != nil {
+		return "", err
+	}
+	armored, err := armor.ArmorWithTypeAndCustomHeaders(
+		sig.Data, constants.PGPSignatureHeader, "", "")
+	if err != nil {
+		return "", err
+	}
+	return armored, nil
+}
+
+// gpgSigner signs by shelling out to the system gpg binary, which in turn
+// delegates passphrase/PIN handling to gpg-agent/pinentry. No passphrase or
+// PIN material is ever passed to or learned by the uploader.
+type gpgSigner struct {
+	binary    string
+	localUser string
+	// env, when non-nil, holds additional environment entries ("KEY=VALUE")
+	// appended to the inherited process environment for the gpg invocation. It
+	// exists so tests can point gpg at an ephemeral GNUPGHOME; production leaves
+	// it nil and gpg inherits the uploader's environment unchanged.
+	env []string
+}
+
+// sign runs the gpg binary to produce an ASCII-armored detached signature over
+// data, which is fed to the process via stdin. The armored signature is read
+// from stdout. On failure the captured stderr is surfaced in the returned
+// error; it is never logged on success.
+func (s *gpgSigner) sign(ctx context.Context, data []byte) (string, error) {
+	// Bound the gpg invocation only. The timeout must leave room for a human
+	// to enter a PIN via pinentry, so it is scoped here rather than around the
+	// whole upload (which has its own, separate lifetime).
+	ctx, cancel := context.WithTimeout(ctx, gpgSignTimeout)
+	defer cancel()
+
+	args := []string{"--batch", "--armor", "--detach-sign"}
+	if s.localUser != "" {
+		args = append(args, "--local-user", s.localUser)
+	}
+	args = append(args, "--output", "-")
+
+	cmd := exec.CommandContext(ctx, s.binary, args...)
+	if s.env != nil {
+		cmd.Env = append(os.Environ(), s.env...)
+	}
+	cmd.Stdin = bytes.NewReader(data)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		// exec.ErrNotFound covers a bare command name missing from $PATH;
+		// fs.ErrNotExist covers a path (absolute or relative) that does not
+		// exist, where the failure only surfaces at fork/exec.
+		if errors.Is(err, exec.ErrNotFound) || errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("gpg binary %q not found: %w", s.binary, err)
+		}
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return "", fmt.Errorf("gpg (%s) failed: %w: %s", s.binary, err, msg)
+		}
+		return "", fmt.Errorf("gpg (%s) failed: %w", s.binary, err)
+	}
+
+	if stdout.Len() == 0 {
+		return "", fmt.Errorf("gpg produced an empty signature")
+	}
+
+	return stdout.String(), nil
+}

--- a/cmd/csaf_uploader/signer_test.go
+++ b/cmd/csaf_uploader/signer_test.go
@@ -1,0 +1,278 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubGPGSource is a tiny standalone program compiled at test time and used as
+// a fake gpg binary. It records its argv and the bytes it received on stdin to
+// files, then emits a configurable stdout / stderr and exits with a
+// configurable status. Behavior is driven by environment variables so a single
+// compiled binary serves every test case.
+//
+//	STUB_ARGS_FILE   path to write the JSON-ish argv dump to (one arg per line)
+//	STUB_STDIN_FILE  path to write the received stdin bytes to
+//	STUB_STDOUT      literal text to write to stdout
+//	STUB_STDERR      literal text to write to stderr
+//	STUB_EXIT        exit code (default 0)
+const stubGPGSource = `package main
+
+import (
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	if f := os.Getenv("STUB_ARGS_FILE"); f != "" {
+		_ = os.WriteFile(f, []byte(strings.Join(os.Args[1:], "\n")), 0o600)
+	}
+	if f := os.Getenv("STUB_STDIN_FILE"); f != "" {
+		data, _ := io.ReadAll(os.Stdin)
+		_ = os.WriteFile(f, data, 0o600)
+	}
+	if s := os.Getenv("STUB_STDOUT"); s != "" {
+		_, _ = os.Stdout.WriteString(s)
+	}
+	if s := os.Getenv("STUB_STDERR"); s != "" {
+		_, _ = os.Stderr.WriteString(s)
+	}
+	code := 0
+	if s := os.Getenv("STUB_EXIT"); s != "" {
+		code, _ = strconv.Atoi(s)
+	}
+	os.Exit(code)
+}
+`
+
+// buildStubGPG compiles the stub program once per test and returns the path to
+// the resulting executable inside a temp dir. The build is fully local; no
+// network or module download is required because the stub has no imports
+// outside the standard library.
+func buildStubGPG(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "stubgpg.go")
+	if err := os.WriteFile(src, []byte(stubGPGSource), 0o600); err != nil {
+		t.Fatalf("writing stub source: %v", err)
+	}
+
+	bin := filepath.Join(dir, "stubgpg")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+
+	// go build of a single self-contained file is offline and deterministic.
+	if out, err := buildGo(t, bin, src); err != nil {
+		t.Fatalf("building stub gpg: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// TestGPGSignerArgsAndStdin covers criteria 5 and 6: the args passed to gpg and
+// the document delivered via stdin, plus stdout passthrough (criterion 4 at the
+// signer level). It runs both with and without a configured local-user.
+func TestGPGSignerArgsAndStdin(t *testing.T) {
+	bin := buildStubGPG(t)
+
+	const armored = "-----BEGIN PGP SIGNATURE-----\n\nSTUBSIG\n-----END PGP SIGNATURE-----\n"
+	doc := []byte(`{"document":"hello"}`)
+
+	tests := []struct {
+		name      string
+		localUser string
+		wantUser  bool
+	}{
+		{name: "without local-user", localUser: ""},
+		{name: "with local-user", localUser: "0xDEADBEEF", wantUser: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			argsFile := filepath.Join(dir, "args")
+			stdinFile := filepath.Join(dir, "stdin")
+
+			t.Setenv("STUB_ARGS_FILE", argsFile)
+			t.Setenv("STUB_STDIN_FILE", stdinFile)
+			t.Setenv("STUB_STDOUT", armored)
+			t.Setenv("STUB_STDERR", "")
+			t.Setenv("STUB_EXIT", "")
+
+			s := &gpgSigner{binary: bin, localUser: tt.localUser}
+			got, err := s.sign(context.Background(), doc)
+			if err != nil {
+				t.Fatalf("sign() unexpected error: %v", err)
+			}
+
+			// stdout is returned verbatim.
+			if got != armored {
+				t.Fatalf("sign() = %q, want %q", got, armored)
+			}
+
+			// stdin equals the document bytes exactly.
+			gotStdin, err := os.ReadFile(stdinFile)
+			if err != nil {
+				t.Fatalf("reading captured stdin: %v", err)
+			}
+			if string(gotStdin) != string(doc) {
+				t.Fatalf("stdin = %q, want %q", gotStdin, doc)
+			}
+
+			// argv assertions.
+			rawArgs, err := os.ReadFile(argsFile)
+			if err != nil {
+				t.Fatalf("reading captured args: %v", err)
+			}
+			args := strings.Split(strings.TrimSpace(string(rawArgs)), "\n")
+			argsJoined := strings.Join(args, " ")
+
+			for _, want := range []string{"--detach-sign", "--armor"} {
+				if !containsArg(args, want) {
+					t.Errorf("args %v missing %q", args, want)
+				}
+			}
+			// --output - present and adjacent.
+			if !containsPair(args, "--output", "-") {
+				t.Errorf("args %v missing %q %q pair", args, "--output", "-")
+			}
+
+			// --local-user present iff configured, with the expected value.
+			if tt.wantUser {
+				if !containsPair(args, "--local-user", tt.localUser) {
+					t.Errorf("args %v missing %q %q pair", args, "--local-user", tt.localUser)
+				}
+			} else if containsArg(args, "--local-user") {
+				t.Errorf("args %v unexpectedly contain --local-user", args)
+			}
+
+			// Never any passphrase / PIN / loopback material.
+			forbidden := []string{
+				"--passphrase",
+				"--passphrase-fd",
+				"--passphrase-file",
+				"--pinentry-mode",
+				"loopback",
+			}
+			for _, f := range forbidden {
+				if strings.Contains(argsJoined, f) {
+					t.Errorf("args %v unexpectedly contain forbidden token %q", args, f)
+				}
+			}
+		})
+	}
+}
+
+// TestGPGSignerNonZeroExit covers criterion 7: a non-zero gpg exit returns an
+// error that includes the captured stderr text.
+func TestGPGSignerNonZeroExit(t *testing.T) {
+	bin := buildStubGPG(t)
+
+	const stderrMsg = "gpg: signing failed: No secret key"
+	t.Setenv("STUB_STDOUT", "")
+	t.Setenv("STUB_STDERR", stderrMsg)
+	t.Setenv("STUB_EXIT", "2")
+
+	s := &gpgSigner{binary: bin}
+	_, err := s.sign(context.Background(), []byte("data"))
+	if err == nil {
+		t.Fatal("sign() = nil error, want failure")
+	}
+	if !strings.Contains(err.Error(), stderrMsg) {
+		t.Fatalf("sign() error %q does not contain stderr %q", err.Error(), stderrMsg)
+	}
+}
+
+// TestGPGSignerEmptyStdout covers criterion 8: exit 0 with empty stdout yields a
+// descriptive error rather than an empty signature.
+func TestGPGSignerEmptyStdout(t *testing.T) {
+	bin := buildStubGPG(t)
+
+	t.Setenv("STUB_STDOUT", "")
+	t.Setenv("STUB_STDERR", "")
+	t.Setenv("STUB_EXIT", "0")
+
+	s := &gpgSigner{binary: bin}
+	got, err := s.sign(context.Background(), []byte("data"))
+	if err == nil {
+		t.Fatalf("sign() = %q, nil error; want descriptive empty-signature error", got)
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("sign() error %q does not describe an empty signature", err.Error())
+	}
+}
+
+// TestGPGSignerBinaryNotFound covers criterion 9: a non-existent binary yields a
+// clear not-found error naming the configured binary. Both forms are exercised
+// because they fail through different paths: a bare command name missing from
+// $PATH surfaces exec.ErrNotFound at construction, while a path that does not
+// exist surfaces fs.ErrNotExist only at fork/exec.
+func TestGPGSignerBinaryNotFound(t *testing.T) {
+	tests := []struct {
+		name   string
+		binary string
+	}{
+		{name: "bare name missing from PATH", binary: "gpg-definitely-not-installed-xyz"},
+		{name: "absolute path that does not exist", binary: "/nonexistent/path/to/gpg-does-not-exist"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &gpgSigner{binary: tt.binary}
+			_, err := s.sign(context.Background(), []byte("data"))
+			if err == nil {
+				t.Fatal("sign() = nil error, want not-found failure")
+			}
+			if !strings.Contains(err.Error(), tt.binary) {
+				t.Fatalf("sign() error %q does not name the binary %q", err.Error(), tt.binary)
+			}
+			if !strings.Contains(err.Error(), "not found") {
+				t.Fatalf("sign() error %q is not the dedicated not-found message", err.Error())
+			}
+		})
+	}
+}
+
+// TestGPGSignTimeoutConstant guards the documented default timeout so an
+// accidental change is noticed.
+func TestGPGSignTimeoutConstant(t *testing.T) {
+	if gpgSignTimeout != 2*time.Minute {
+		t.Fatalf("gpgSignTimeout = %v, want %v", gpgSignTimeout, 2*time.Minute)
+	}
+}
+
+// containsArg reports whether args contains exactly token.
+func containsArg(args []string, token string) bool {
+	for _, a := range args {
+		if a == token {
+			return true
+		}
+	}
+	return false
+}
+
+// containsPair reports whether args contains flag immediately followed by value.
+func containsPair(args []string, flag, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/csaf_uploader.md
+++ b/docs/csaf_uploader.md
@@ -11,6 +11,9 @@ Application Options:
   -t, --tlp=[csaf|white|green|amber|red]    TLP of the feed (default: csaf)
   -x, --external_signed                     CSAF files are signed externally. Assumes .asc files beside CSAF files.
   -s, --no_schema_check                     Do not check files against CSAF JSON schema locally.
+      --gpg                                 Sign CSAF files via the system gpg binary (delegates passphrase/PIN to gpg-agent)
+      --gpg-user=IDENTITY                   Signing key identity for gpg --local-user (fingerprint/email/keyid)
+      --gpg-binary=GPG-BIN                  Path to the gpg executable (default: gpg)
   -k, --key=KEY-FILE                        OpenPGP key to sign the CSAF files
   -p, --password=PASSWORD                   Authentication password for accessing the CSAF provider
   -P, --passphrase=PASSPHRASE               Passphrase to unlock the OpenPGP key
@@ -49,6 +52,26 @@ To upload an already signed document, use the `-x` option
 ./csaf_uploader -x -a upload -I -t white -u https://localhost/cgi-bin/csaf_provider.go  CSAF-document-1.json
 ```
 
+#### Signing with gpg-agent (hardware tokens / smartcards)
+
+```bash
+./csaf_uploader -a upload --gpg --gpg-user 0xDEADBEEF -t white \
+  -u https://localhost/cgi-bin/csaf_provider.go CSAF-document-1.json
+```
+
+The `--gpg` flag enables signing via the system `gpg` binary, which delegates to
+`gpg-agent`. This lets the private key live on a smartcard / YubiKey / HSM and
+never enter csaf_uploader. The PIN or passphrase is handled by gpg's pinentry,
+not by csaf_uploader, so no passphrase ever flows through the uploader.
+
+`--gpg-user` is optional and selects the signing key (fingerprint, email or
+keyid via `gpg --local-user`); omit it to use gpg's default key. `--gpg-binary`
+overrides the path to the gpg executable (default: `gpg`).
+
+`--gpg` is mutually exclusive with `-k/--key` and `-x/--external_signed`, and the
+`-P/--passphrase` and `-I/--passphrase_interactive` options are ignored in gpg
+mode. This mode requires a working `gpg` installation with a running `gpg-agent`.
+
 By default csaf_uploader will try to load a config file
 from the following places:
 
@@ -65,6 +88,10 @@ url                    = "https://localhost/cgi-bin/csaf_provider.go"
 tlp                    = "csaf"
 external_signed        = false
 no_schema_check        = false
+# gpg                  = false                              # not set by default
+# gpg_user             = "0xDEADBEEF"                       # not set by default
+# gpg_user             = "integration@example.com"          # alterative to above
+# gpg_binary           = "gpg"                              # default: gpg
 # key                  = "/path/to/openpgp/key/file"       # not set by default
 # password             = "auth-key to access the provider" # not set by default
 # passphrase           = "OpenPGP passphrase"              # not set by default


### PR DESCRIPTION
Implements #734

Add a --gpg mode that produces the armored detached signature by shelling out to the system gpg binary, delegating passphrase/PIN handling to gpg-agent/pinentry. This lets the signing key live on a smartcard, YubiKey or other hardware token instead of being an exported key file loaded into the uploader process.

New flags:
  --gpg          enable signing via the system gpg
  --gpg-user     signing key identity for gpg --local-user (optional)
  --gpg-binary   path to the gpg executable (default: gpg)

Signing is routed through a small internal signer interface (keyRingSigner for the existing in-process gopenpgp path, gpgSigner for the new exec path), so uploadRequest has a single call site per mode. --gpg is mutually exclusive with -k/--key and -x/--external_signed; -P/-I are ignored in gpg mode. The on-the-wire signature field is unchanged (ASCII-armored detached OpenPGP signature), so csaf_provider verifies it without changes.

The existing no-sign, file-key and external-signed modes are unchanged.

Includes unit tests (gpg invocation driven by a stub binary) and a gated integration test that created a temp GPGHOME, generates a fresh gpg key, signs with a real gpg and verifies using the gopenpgp library.