### PR TITLE
Uploader: add option to call external signing tool

### DIFF
--- a/cmd/csaf_uploader/config.go
+++ b/cmd/csaf_uploader/config.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 	"golang.org/x/crypto/bcrypt"
@@ -34,10 +35,11 @@ type config struct {
 	Action string `short:"a" long:"action" choice:"upload" choice:"create" description:"Action to perform" toml:"action"`
 	URL    string `short:"u" long:"url" description:"URL of the CSAF provider" value-name:"URL" toml:"url"`
 	//lint:ignore SA5008 We are using choice many times: csaf, white, green, amber, red.
-	TLP            string `short:"t" long:"tlp" choice:"csaf" choice:"white" choice:"green" choice:"amber" choice:"red" description:"TLP of the feed" toml:"tlp"`
-	ExternalSigned bool   `short:"x" long:"external_signed" description:"CSAF files are signed externally. Assumes .asc files beside CSAF files." toml:"external_signed"`
-	SigningTool    string `short:"X" long:"signing_tool" description:"Tool to sign a file externally" toml:"signing_tool"`
-	NoSchemaCheck  bool   `short:"s" long:"no_schema_check" description:"Do not check files against CSAF JSON schema locally." toml:"no_schema_check"`
+	TLP                string        `short:"t" long:"tlp" choice:"csaf" choice:"white" choice:"green" choice:"amber" choice:"red" description:"TLP of the feed" toml:"tlp"`
+	ExternalSigned     bool          `short:"x" long:"external_signed" description:"CSAF files are signed externally. Assumes .asc files beside CSAF files." toml:"external_signed"`
+	SigningTool        string        `short:"X" long:"signing_tool" description:"Tool to sign a file externally" toml:"signing_tool"`
+	SigningToolTimeout time.Duration `long:"signing_tool_timeout" description:"Timeout for the external signing tool" toml:"signing_tool_timeout"`
+	NoSchemaCheck      bool          `short:"s" long:"no_schema_check" description:"Do not check files against CSAF JSON schema locally." toml:"no_schema_check"`
 
 	Key              *string `short:"k" long:"key" description:"OpenPGP key to sign the CSAF files" value-name:"KEY-FILE" toml:"key"`
 	Password         *string `short:"p" long:"password" description:"Authentication password for accessing the CSAF provider" value-name:"PASSWORD" toml:"password"`

--- a/cmd/csaf_uploader/config.go
+++ b/cmd/csaf_uploader/config.go
@@ -36,6 +36,7 @@ type config struct {
 	//lint:ignore SA5008 We are using choice many times: csaf, white, green, amber, red.
 	TLP            string `short:"t" long:"tlp" choice:"csaf" choice:"white" choice:"green" choice:"amber" choice:"red" description:"TLP of the feed" toml:"tlp"`
 	ExternalSigned bool   `short:"x" long:"external_signed" description:"CSAF files are signed externally. Assumes .asc files beside CSAF files." toml:"external_signed"`
+	SigningTool    string `short:"X" long:"signing_tool" description:"Tool to sign a file externally" toml:"signing_tool"`
 	NoSchemaCheck  bool   `short:"s" long:"no_schema_check" description:"Do not check files against CSAF JSON schema locally." toml:"no_schema_check"`
 
 	Key              *string `short:"k" long:"key" description:"OpenPGP key to sign the CSAF files" value-name:"KEY-FILE" toml:"key"`

--- a/cmd/csaf_uploader/kill_other.go
+++ b/cmd/csaf_uploader/kill_other.go
@@ -1,0 +1,21 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2022, 2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+
+//go:build !unix
+
+package main
+
+import (
+	"log"
+	"os/exec"
+)
+
+// prepareKillingProcessGroup is currently not implemented on other platforms than unix-likes.
+func prepareKillingProcessGroup(*exec.Cmd) {
+	log.Println("Warning: creating a process is not implemented on this platform")
+}

--- a/cmd/csaf_uploader/kill_other.go
+++ b/cmd/csaf_uploader/kill_other.go
@@ -17,5 +17,5 @@ import (
 
 // prepareKillingProcessGroup is currently not implemented on other platforms than unix-likes.
 func prepareKillingProcessGroup(*exec.Cmd) {
-	log.Println("Warning: creating a process is not implemented on this platform")
+	log.Println("Warning: creating a process group is not implemented on this platform.")
 }

--- a/cmd/csaf_uploader/kill_unix.go
+++ b/cmd/csaf_uploader/kill_unix.go
@@ -1,0 +1,27 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2022, 2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+
+//go:build unix
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// prepareKillingProcessGroup creates a new process group to be killed
+// if the timeout is reached.
+func prepareKillingProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}

--- a/cmd/csaf_uploader/processor.go
+++ b/cmd/csaf_uploader/processor.go
@@ -18,6 +18,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -173,7 +174,17 @@ func (p *processor) uploadRequest(filename string) (*http.Request, error) {
 		}
 	}
 
-	if p.cfg.ExternalSigned {
+	switch {
+	case p.cfg.SigningTool != "":
+		signature, err := p.signExternally(data)
+		if err != nil {
+			return nil, err
+		}
+		if err := writer.WriteField("signature", signature); err != nil {
+			return nil, err
+		}
+
+	case p.cfg.ExternalSigned:
 		signature, err := os.ReadFile(filename + ".asc")
 		if err != nil {
 			return nil, err
@@ -254,6 +265,32 @@ func (p *processor) process(filename string) error {
 	writeStrings("Errors:", result.Errors)
 
 	return uploadErr
+}
+
+func (p *processor) signExternally(data []byte) (string, error) {
+	if p.cfg.SigningTool == "" {
+		return "", errors.New("no signing tool specified")
+	}
+	var output bytes.Buffer
+	cmd := exec.Command(p.cfg.SigningTool)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = &output
+	input, err := cmd.StdinPipe()
+	if err != nil {
+		return "", fmt.Errorf("cannot get stdin from signing tool: %w", err)
+	}
+	errChan := make(chan error)
+	go func() {
+		_, err := input.Write(data)
+		errChan <- errors.Join(err, input.Close())
+	}()
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("running signing tool failed: %w", err)
+	}
+	if err := <-errChan; err != nil {
+		return "", fmt.Errorf("writing advisory to signing tool failed: %w", err)
+	}
+	return output.String(), nil
 }
 
 func (p *processor) run(args []string) error {

--- a/cmd/csaf_uploader/processor.go
+++ b/cmd/csaf_uploader/processor.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ProtonMail/gopenpgp/v2/armor"
 	"github.com/ProtonMail/gopenpgp/v2/constants"
@@ -283,6 +284,11 @@ func (p *processor) signExternally(data []byte) (string, error) {
 	cmd.Stdin = bytes.NewReader(data)
 	cmd.Stdout = &output
 	cmd.Stderr = os.Stderr
+	cmd.WaitDelay = 500 * time.Millisecond
+	// Create a process group to be killed.
+	if p.cfg.SigningToolTimeout > 0 {
+		prepareKillingProcessGroup(cmd)
+	}
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("running signing tool failed: %w", err)
 	}

--- a/cmd/csaf_uploader/processor.go
+++ b/cmd/csaf_uploader/processor.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -271,24 +272,19 @@ func (p *processor) signExternally(data []byte) (string, error) {
 	if p.cfg.SigningTool == "" {
 		return "", errors.New("no signing tool specified")
 	}
-	var output bytes.Buffer
-	cmd := exec.Command(p.cfg.SigningTool)
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = &output
-	input, err := cmd.StdinPipe()
-	if err != nil {
-		return "", fmt.Errorf("cannot get stdin from signing tool: %w", err)
+	ctx := context.Background()
+	if p.cfg.SigningToolTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, p.cfg.SigningToolTimeout)
+		defer cancel()
 	}
-	errChan := make(chan error)
-	go func() {
-		_, err := input.Write(data)
-		errChan <- errors.Join(err, input.Close())
-	}()
+	var output bytes.Buffer
+	cmd := exec.CommandContext(ctx, p.cfg.SigningTool)
+	cmd.Stdin = bytes.NewReader(data)
+	cmd.Stdout = &output
+	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("running signing tool failed: %w", err)
-	}
-	if err := <-errChan; err != nil {
-		return "", fmt.Errorf("writing advisory to signing tool failed: %w", err)
 	}
 	return output.String(), nil
 }

--- a/docs/csaf_uploader.md
+++ b/docs/csaf_uploader.md
@@ -10,6 +10,7 @@ Application Options:
   -u, --url=URL                             URL of the CSAF provider (default: https://localhost/cgi-bin/csaf_provider.go)
   -t, --tlp=[csaf|white|green|amber|red]    TLP of the feed (default: csaf)
   -x, --external_signed                     CSAF files are signed externally. Assumes .asc files beside CSAF files.
+  -X, --signing_tool                        Tool to sign a file externally
   -s, --no_schema_check                     Do not check files against CSAF JSON schema locally.
   -k, --key=KEY-FILE                        OpenPGP key to sign the CSAF files
   -p, --password=PASSWORD                   Authentication password for accessing the CSAF provider
@@ -49,6 +50,12 @@ To upload an already signed document, use the `-x` option
 ./csaf_uploader -x -a upload -I -t white -u https://localhost/cgi-bin/csaf_provider.go  CSAF-document-1.json
 ```
 
+To use external tool for signing
+```bash
+./csaf_uploader --signing_tool signing_tool.sh white -u https://localhost/cgi-bin/csaf_provider.go  CSAF-document-1.json
+```
+Example script under csaf/docs/scripts/signing_tool.sh
+
 By default csaf_uploader will try to load a config file
 from the following places:
 
@@ -64,6 +71,7 @@ action                 = "upload"
 url                    = "https://localhost/cgi-bin/csaf_provider.go"
 tlp                    = "csaf"
 external_signed        = false
+signing_tool           = ""
 no_schema_check        = false
 # key                  = "/path/to/openpgp/key/file"       # not set by default
 # password             = "auth-key to access the provider" # not set by default

--- a/docs/csaf_uploader.md
+++ b/docs/csaf_uploader.md
@@ -62,6 +62,10 @@ Example script under `csaf/docs/scripts/signing_tool.sh`
 There is an optional timeout `signing_tool_timeout` which - if set to values greater 0 - stops the external call after the given duration.
 It defaults to 0. Valid durations are decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
+Attention: This currently works only fully on Unix-like systems. Only on these platforms
+it is ensured that all sub processes created by the external signing tool are killed when the
+timeout is reached. On other platforms the timeout may have no effect.
+
 By default csaf_uploader will try to load a config file
 from the following places:
 

--- a/docs/csaf_uploader.md
+++ b/docs/csaf_uploader.md
@@ -3,21 +3,25 @@
 ### Usage
 
 ```
-csaf_uploader [OPTIONS]
+csaf_uploader [OPTIONS] advisories...
 
 Application Options:
   -a, --action=[upload|create]              Action to perform (default: upload)
-  -u, --url=URL                             URL of the CSAF provider (default: https://localhost/cgi-bin/csaf_provider.go)
+  -u, --url=URL                             URL of the CSAF provider (default:
+                                            https://localhost/cgi-bin/csaf_provider.go)
   -t, --tlp=[csaf|white|green|amber|red]    TLP of the feed (default: csaf)
-  -x, --external_signed                     CSAF files are signed externally. Assumes .asc files beside CSAF files.
-  -X, --signing_tool                        Tool to sign a file externally
+  -x, --external_signed                     CSAF files are signed externally. Assumes .asc files beside
+                                            CSAF files.
+  -X, --signing_tool=                       Tool to sign a file externally
+      --signing_tool_timeout=               Timeout for the external signing tool
   -s, --no_schema_check                     Do not check files against CSAF JSON schema locally.
   -k, --key=KEY-FILE                        OpenPGP key to sign the CSAF files
   -p, --password=PASSWORD                   Authentication password for accessing the CSAF provider
   -P, --passphrase=PASSPHRASE               Passphrase to unlock the OpenPGP key
       --client_cert=CERT-FILE.crt           TLS client certificate file (PEM encoded data)
       --client_key=KEY-FILE.pem             TLS client private key file (PEM encoded data)
-      --client_passphrase=PASSPHRASE        Optional passphrase for the client cert (limited, experimental, see downloader doc)
+      --client_passphrase=PASSPHRASE        Optional passphrase for the client cert (limited,
+                                            experimental, see downloader doc)
   -i, --password_interactive                Enter password interactively
   -I, --passphrase_interactive              Enter OpenPGP key passphrase interactively
       --insecure                            Do not check TLS certificates from provider
@@ -54,7 +58,9 @@ To use external tool for signing
 ```bash
 ./csaf_uploader --signing_tool signing_tool.sh white -u https://localhost/cgi-bin/csaf_provider.go  CSAF-document-1.json
 ```
-Example script under csaf/docs/scripts/signing_tool.sh
+Example script under `csaf/docs/scripts/signing_tool.sh`
+There is an optional timeout `signing_tool_timeout` which - if set to values greater 0 - stops the external call after the given duration.
+It defaults to 0. Valid durations are decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
 By default csaf_uploader will try to load a config file
 from the following places:

--- a/docs/scripts/signing_tool.sh
+++ b/docs/scripts/signing_tool.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+gpg --armor --detach-sign --output - -


### PR DESCRIPTION
This PR adds an option to call an external signing tool:

```
-X, --signing_tool=                    Tool to sign a file externally
      --signing_tool_timeout=   Timeout for the external signing tool
```

The idea is to enable using an external tool like `gpg` to sign
an advisory before uploading it to the provider.
The advisory is piped to the tool via stdin. The signature is captured from stdout.

TODO:
- [x] Documentation
- [x] Example
- [x] Test