### PR TITLE
csaf: drop null entries when loading a ROLIE feed

### DIFF
--- a/csaf/rolie.go
+++ b/csaf/rolie.go
@@ -11,6 +11,7 @@ package csaf
 import (
 	"encoding/json"
 	"io"
+	"slices"
 	"sort"
 	"time"
 
@@ -208,6 +209,11 @@ func LoadROLIEFeed(r io.Reader) (*ROLIEFeed, error) {
 	if err := misc.StrictJSONParse(r, &rf); err != nil {
 		return nil, err
 	}
+	// A JSON null inside the entry array unmarshals to a nil *Entry.
+	// Drop those here so consumers can rely on all entries being non-nil.
+	rf.Feed.Entry = slices.DeleteFunc(rf.Feed.Entry, func(e *Entry) bool {
+		return e == nil
+	})
 	return &rf, nil
 }
 

--- a/csaf/rolie_test.go
+++ b/csaf/rolie_test.go
@@ -1,0 +1,56 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+
+package csaf
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadROLIEFeedNullEntry(t *testing.T) {
+	tests := []struct {
+		name  string
+		feed  string
+		count int
+	}{
+		{
+			name:  "only null entry",
+			feed:  `{"feed":{"id":"x","title":"t","updated":"2020-01-01T00:00:00Z","entry":[null]}}`,
+			count: 0,
+		},
+		{
+			name: "null entry mixed with a real one",
+			feed: `{"feed":{"id":"x","title":"t","updated":"2020-01-01T00:00:00Z","entry":[` +
+				`null,{"id":"a","title":"a","updated":"2021-01-01T00:00:00Z"}]}}`,
+			count: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rf, err := LoadROLIEFeed(strings.NewReader(tt.feed))
+			if err != nil {
+				t.Fatalf("LoadROLIEFeed failed: %v", err)
+			}
+			if got := rf.CountEntries(); got != tt.count {
+				t.Errorf("CountEntries: got %d, want %d", got, tt.count)
+			}
+			rf.Entries(func(entry *Entry) {
+				if entry == nil {
+					t.Fatal("Entries visited a nil entry")
+				}
+				_ = entry.ID
+			})
+			rf.SortEntriesByUpdated()
+			if e := rf.EntryByID("a"); tt.count > 0 && e == nil {
+				t.Error("EntryByID did not find the real entry")
+			}
+		})
+	}
+}


### PR DESCRIPTION
A `null` inside a ROLIE feed's `entry` array parses fine (`StrictJSONParse` is happy with it) and lands in `FeedData.Entry` as a nil `*Entry`. Nothing downstream expects that, so the first consumer to touch it panics.

```
{"feed":{"id":"x","title":"t","updated":"2020-01-01T00:00:00Z","entry":[null]}}
```

Against that feed, `Entries` hands the nil straight to the callback and the downloader's callback in `csaf/advisories.go` does `time.Time(entry.Updated)` right away:

```
panic: runtime error: invalid memory address or nil pointer dereference
	github.com/gocsaf/csaf/v3/csaf.(*ROLIEFeed).Entries(...)
		csaf/rolie.go:237
```

`SortEntriesByUpdated` and `EntryByID` go the same way. These feeds come off remote providers, so csaf_downloader/csaf_aggregator/csaf_checker all reach it with input they don't control. The aggregator case is the annoying one since one bad provider takes down the whole run.

I dropped the nil entries in `LoadROLIEFeed` instead of guarding each consumer, that way the invariant holds for external callers too. Test covers the null-only feed and a null mixed in with a real entry (`sort.Slice` skips the comparator on a length-1 slice, so the sort path needs two).

`go test ./csaf/...` passes.
