### PR TITLE
Prevent large buffers used in dowloading

### DIFF
--- a/cmd/csaf_aggregator/full.go
+++ b/cmd/csaf_aggregator/full.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/internal/misc"
 	"github.com/gocsaf/csaf/v3/util"
 )
 
@@ -107,9 +108,11 @@ func (p *processor) full(ctx context.Context) error {
 
 	p.log.Info("Starting workers...", "num", p.cfg.Workers)
 
+	pool := misc.NewBufferPool(p.cfg.Workers)
+
 	for i := 1; i <= p.cfg.Workers; i++ {
 		wg.Add(1)
-		w := newWorker(i, p)
+		w := newWorker(i, p, pool)
 
 		go w.fullWork(ctx, &wg, queue)
 	}

--- a/cmd/csaf_aggregator/interim.go
+++ b/cmd/csaf_aggregator/interim.go
@@ -73,17 +73,17 @@ func (w *worker) checkInterims(
 				url, res.StatusCode, res.Status)
 		}
 
-		s256 := sha256.New()
-		data := w.pool.Get()
+		var (
+			s256   = sha256.New()
+			data   = w.pool.Get()
+			hasher = io.MultiWriter(s256, data)
+			tee    = io.TeeReader(res.Body, hasher)
+			doc    any
+		)
 		defer w.pool.Put(data)
-		hasher := io.MultiWriter(s256, data)
-
-		var doc any
-		if err := func() error {
-			defer res.Body.Close()
-			tee := io.TeeReader(res.Body, hasher)
-			return misc.StrictJSONParse(tee, &doc)
-		}(); err != nil {
+		err = misc.StrictJSONParse(tee, &doc)
+		res.Body.Close()
+		if err != nil {
 			return err
 		}
 

--- a/cmd/csaf_aggregator/interim.go
+++ b/cmd/csaf_aggregator/interim.go
@@ -48,36 +48,34 @@ func (w *worker) checkInterims(
 	interims []interimsEntry,
 ) ([]interimsEntry, error) {
 
-	var data bytes.Buffer
-
 	labelPath := filepath.Join(tx.Src(), label)
 
 	// advisories which are not interim any longer.
 	var notFinalized []interimsEntry
 
-	for _, interim := range interims {
-
+	processIterim := func(interim interimsEntry) error {
 		local := filepath.Join(labelPath, interim.path())
 		url := interim.url()
 
 		// Load local SHA256 of the advisory
 		localHash, err := util.HashFromFile(local + ".sha256")
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		res, err := w.client.GetWithContext(ctx, url)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if res.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("fetching %s failed: Status code %d (%s)",
+			return fmt.Errorf("fetching %s failed: Status code %d (%s)",
 				url, res.StatusCode, res.Status)
 		}
 
 		s256 := sha256.New()
-		data.Reset()
-		hasher := io.MultiWriter(s256, &data)
+		data := w.pool.Get()
+		defer w.pool.Put(data)
+		hasher := io.MultiWriter(s256, data)
 
 		var doc any
 		if err := func() error {
@@ -85,7 +83,7 @@ func (w *worker) checkInterims(
 			tee := io.TeeReader(res.Body, hasher)
 			return misc.StrictJSONParse(tee, &doc)
 		}(); err != nil {
-			return nil, err
+			return err
 		}
 
 		remoteHash := s256.Sum(nil)
@@ -93,12 +91,12 @@ func (w *worker) checkInterims(
 		// If the hashes are equal then we can ignore this advisory.
 		if bytes.Equal(localHash, remoteHash) {
 			notFinalized = append(notFinalized, interim)
-			continue
+			return nil
 		}
 
 		errors, err := csaf.ValidateCSAF(doc)
 		if err != nil {
-			return nil, fmt.Errorf("failed to validate %s: %v", url, err)
+			return fmt.Errorf("failed to validate %s: %v", url, err)
 		}
 
 		// XXX: Should we return an error here?
@@ -111,7 +109,7 @@ func (w *worker) checkInterims(
 		// This will start the transaction if not already started.
 		dst, err := tx.Dst()
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		// Overwrite in the cloned folder.
@@ -120,7 +118,7 @@ func (w *worker) checkInterims(
 		bytes := data.Bytes()
 
 		if err := os.WriteFile(nlocal, bytes, 0644); err != nil {
-			return nil, err
+			return err
 		}
 
 		name := filepath.Base(nlocal)
@@ -128,12 +126,12 @@ func (w *worker) checkInterims(
 		if err := util.WriteHashToFile(
 			nlocal+".sha512", name, sha512.New(), bytes,
 		); err != nil {
-			return nil, err
+			return err
 		}
 		if err := util.WriteHashSumToFile(
 			nlocal+".sha256", name, remoteHash,
 		); err != nil {
-			return nil, err
+			return err
 		}
 
 		// Download the signature
@@ -142,16 +140,23 @@ func (w *worker) checkInterims(
 
 		// Download the signature or sign it our self.
 		if err := w.downloadSignatureOrSign(ctx, sigURL, ascFile, bytes); err != nil {
-			return nil, err
+			return err
 		}
 
 		// Check if we can remove this advisory as it is not interim any more.
 		var status string
 		if err := w.expr.Extract(statusExpr, util.StringMatcher(&status), true, doc); err != nil {
-			return nil, err
+			return err
 		}
 		if status == "interim" {
 			notFinalized = append(notFinalized, interim)
+		}
+		return nil
+	}
+
+	for _, interim := range interims {
+		if err := processIterim(interim); err != nil {
+			return nil, err
 		}
 	}
 
@@ -262,10 +267,12 @@ func (p *processor) interim(ctx context.Context) error {
 	queue := make(chan *interimJob)
 	var wg sync.WaitGroup
 
+	pool := misc.NewBufferPool(p.cfg.Workers)
+
 	p.log.Info("Starting workers...", "num", p.cfg.Workers)
 	for i := 1; i <= p.cfg.Workers; i++ {
 		wg.Add(1)
-		w := newWorker(i, p)
+		w := newWorker(i, p, pool)
 		go w.interimWork(ctx, &wg, queue)
 	}
 

--- a/cmd/csaf_aggregator/mirror.go
+++ b/cmd/csaf_aggregator/mirror.go
@@ -54,7 +54,9 @@ func (w *worker) mirror(ctx context.Context) (*csaf.AggregatorCSAFProvider, erro
 	return result, err
 }
 
-func (w *worker) mirrorInternal(ctx context.Context) (*csaf.AggregatorCSAFProvider, error) {
+func (w *worker) mirrorInternal(
+	ctx context.Context,
+) (*csaf.AggregatorCSAFProvider, error) {
 
 	// Check if we are allowed to mirror this domain.
 	if !w.mirrorAllowed() {
@@ -499,7 +501,11 @@ func (w *worker) mirrorFiles(ctx context.Context) func(csaf.TLPLabel, []csaf.Adv
 	}
 }
 
-func (w *worker) mirrorFilesWithContext(ctx context.Context, tlpLabel csaf.TLPLabel, files []csaf.AdvisoryFile) error {
+func (w *worker) mirrorFilesWithContext(
+	ctx context.Context,
+	tlpLabel csaf.TLPLabel,
+	files []csaf.AdvisoryFile,
+) error {
 	label := strings.ToLower(string(tlpLabel))
 
 	summaries := w.summaries[label]
@@ -509,16 +515,14 @@ func (w *worker) mirrorFilesWithContext(ctx context.Context, tlpLabel csaf.TLPLa
 		return err
 	}
 
-	var content bytes.Buffer
-
 	yearDirs := make(map[int]string)
 
-	for _, file := range files {
+	mirrorFile := func(file csaf.AdvisoryFile) error {
 
 		u, err := url.Parse(file.URL())
 		if err != nil {
 			w.log.Error("Could not parse advisory file URL", "err", err)
-			continue
+			return nil
 		}
 
 		// Should we ignore this advisory?
@@ -526,22 +530,23 @@ func (w *worker) mirrorFilesWithContext(ctx context.Context, tlpLabel csaf.TLPLa
 			if w.processor.cfg.Verbose {
 				w.log.Info("Ignoring advisory", slog.Group("provider", "name", w.provider.Name), "file", file)
 			}
-			continue
+			return nil
 		}
 
 		// Ignore not conforming filenames.
 		filename := filepath.Base(u.Path)
 		if !util.ConformingFileName(filename) {
 			w.log.Warn("Ignoring advisory because of non-conforming filename", "filename", filename)
-			continue
+			return nil
 		}
 
 		var advisory any
 
 		s256 := sha256.New()
 		s512 := sha512.New()
-		content.Reset()
-		hasher := io.MultiWriter(s256, s512, &content)
+		content := w.pool.Get()
+		defer w.pool.Put(content)
+		hasher := io.MultiWriter(s256, s512, content)
 
 		download := func(r io.Reader) error {
 			tee := io.TeeReader(r, hasher)
@@ -550,18 +555,18 @@ func (w *worker) mirrorFilesWithContext(ctx context.Context, tlpLabel csaf.TLPLa
 
 		if err := downloadJSON(ctx, w.client, file.URL(), download); err != nil {
 			w.log.Error("Error while downloading JSON", "err", err)
-			continue
+			return nil
 		}
 
 		// Check against CSAF schema.
 		errors, err := csaf.ValidateCSAF(advisory)
 		if err != nil {
 			w.log.Error("Error while validating CSAF schema", "err", err)
-			continue
+			return nil
 		}
 		if len(errors) > 0 {
 			w.log.Error("CSAF file has validation errors", "num.errors", len(errors), "file", file)
-			continue
+			return nil
 		}
 
 		// Check against remote validator.
@@ -569,18 +574,18 @@ func (w *worker) mirrorFilesWithContext(ctx context.Context, tlpLabel csaf.TLPLa
 			rvr, err := rmv.ValidateWithContext(ctx, advisory)
 			if err != nil {
 				w.log.Error("Calling remote validator failed", "err", err)
-				continue
+				return nil
 			}
 			if !rvr.Valid {
 				w.log.Error("CSAF file does not validate remotely", "file", file.URL())
-				continue
+				return nil
 			}
 		}
 
 		sum, err := csaf.NewAdvisorySummary(w.expr, advisory)
 		if err != nil {
 			w.log.Error("Error while creating new advisory", "file", file, "err", err)
-			continue
+			return nil
 		}
 
 		if util.CleanFileName(sum.ID) != filename {
@@ -589,7 +594,7 @@ func (w *worker) mirrorFilesWithContext(ctx context.Context, tlpLabel csaf.TLPLa
 
 		if err := w.extractCategories(label, advisory); err != nil {
 			w.log.Error("Could not extract categories", "file", file, "err", err)
-			continue
+			return nil
 		}
 
 		summaries = append(summaries, summary{
@@ -621,7 +626,11 @@ func (w *worker) mirrorFilesWithContext(ctx context.Context, tlpLabel csaf.TLPLa
 		// Try to fetch signature file.
 		sigURL := file.SignURL()
 		ascFile := fname + ".asc"
-		if err := w.downloadSignatureOrSign(ctx, sigURL, ascFile, data); err != nil {
+		return w.downloadSignatureOrSign(ctx, sigURL, ascFile, data)
+	}
+
+	for _, file := range files {
+		if err := mirrorFile(file); err != nil {
 			return err
 		}
 	}

--- a/cmd/csaf_aggregator/processor.go
+++ b/cmd/csaf_aggregator/processor.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 
 	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/internal/misc"
 	"github.com/gocsaf/csaf/v3/util"
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
@@ -55,14 +56,16 @@ type worker struct {
 	summaries        map[string][]summary        // the summaries of the advisories.
 	categories       map[string]util.Set[string] // the categories per label.
 	log              *slog.Logger                // the structured logger, supplied with the worker number.
+	pool             misc.BufferPool
 }
 
-func newWorker(num int, processor *processor) *worker {
+func newWorker(num int, processor *processor, pool misc.BufferPool) *worker {
 	return &worker{
 		num:       num,
 		processor: processor,
 		expr:      util.NewPathEval(),
 		log:       processor.log.With(slog.Int("worker", num)),
+		pool:      pool,
 	}
 }
 

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -636,6 +636,11 @@ func makeAbsolute(base *url.URL) func(*url.URL) *url.URL {
 
 var yearFromURL = regexp.MustCompile(`.*/(\d{4})/[^/]+$`)
 
+const (
+	minBufSize = 1 * 1024 * 1024
+	maxBufSize = 4 * 1024 * 1024
+)
+
 // integrity checks several csaf.AdvisoryFiles for formal
 // mistakes, from conforming filenames to invalid advisories.
 func (p *processor) integrity(
@@ -646,7 +651,7 @@ func (p *processor) integrity(
 ) error {
 	client := p.httpClient()
 
-	var data bytes.Buffer
+	data := bytes.NewBuffer(make([]byte, 0, minBufSize))
 
 	for _, f := range files {
 		fp, err := url.Parse(f.URL())
@@ -702,8 +707,13 @@ func (p *processor) integrity(
 
 		s256 := sha256.New()
 		s512 := sha512.New()
-		data.Reset()
-		hasher := io.MultiWriter(s256, s512, &data)
+
+		if data.Cap() >= maxBufSize { // Throw away if buffer gets too big.
+			data = bytes.NewBuffer(make([]byte, 0, minBufSize))
+		} else {
+			data.Reset()
+		}
+		hasher := io.MultiWriter(s256, s512, data)
 
 		var doc any
 

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -636,11 +636,6 @@ func makeAbsolute(base *url.URL) func(*url.URL) *url.URL {
 
 var yearFromURL = regexp.MustCompile(`.*/(\d{4})/[^/]+$`)
 
-const (
-	minBufSize = 1 * 1024 * 1024
-	maxBufSize = 4 * 1024 * 1024
-)
-
 // integrity checks several csaf.AdvisoryFiles for formal
 // mistakes, from conforming filenames to invalid advisories.
 func (p *processor) integrity(
@@ -651,7 +646,7 @@ func (p *processor) integrity(
 ) error {
 	client := p.httpClient()
 
-	data := bytes.NewBuffer(make([]byte, 0, minBufSize))
+	data := bytes.NewBuffer(make([]byte, 0, misc.MinBufSize))
 
 	for _, f := range files {
 		fp, err := url.Parse(f.URL())
@@ -708,8 +703,8 @@ func (p *processor) integrity(
 		s256 := sha256.New()
 		s512 := sha512.New()
 
-		if data.Cap() >= maxBufSize { // Throw away if buffer gets too big.
-			data = bytes.NewBuffer(make([]byte, 0, minBufSize))
+		if data.Cap() > misc.MaxBufSize { // Throw away if buffer gets too big.
+			data = bytes.NewBuffer(make([]byte, 0, misc.MinBufSize))
 		} else {
 			data.Reset()
 		}

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -283,12 +283,9 @@ func (d *downloader) downloadFiles(
 		}
 	}()
 
-	var n int
-	if n = d.cfg.Worker; n < 1 {
-		n = 1
-	}
+	n := min(d.cfg.Worker, 1)
 
-	pool := newDownloaderPool(n)
+	pool := misc.NewBufferPool(n)
 
 	for range n {
 		wg.Add(1)
@@ -420,43 +417,12 @@ func (d *downloader) logValidationIssues(url string, errors []string, err error)
 	}
 }
 
-// downloaderPool is a leaky buffer to avoid memory allocations.
-type downloaderPool chan (*bytes.Buffer)
-
-func newDownloaderPool(items int) downloaderPool {
-	return make(downloaderPool, items)
-}
-
-const (
-	minBufSize = 1 * 1024 * 1024
-	maxBufSize = 4 * 1024 * 1024
-)
-
-func (dp downloaderPool) get() *bytes.Buffer {
-	select {
-	case buf := <-dp:
-		return buf
-	default:
-		return bytes.NewBuffer(make([]byte, 0, minBufSize))
-	}
-}
-
-func (dp downloaderPool) put(buf *bytes.Buffer) {
-	if buf.Cap() < maxBufSize { // Throw away if too large.
-		buf.Reset()
-		select {
-		case dp <- buf:
-		default:
-		}
-	}
-}
-
 // downloadContext stores the common context of a downloader.
 type downloadContext struct {
 	d      *downloader
 	client util.ClientWithContext
 	//data               bytes.Buffer
-	pool               downloaderPool
+	pool               misc.BufferPool
 	lastDir            string
 	initialReleaseDate time.Time
 	dateExtract        func(any) error
@@ -468,7 +434,7 @@ type downloadContext struct {
 func newDownloadContext(
 	d *downloader,
 	label csaf.TLPLabel,
-	pool downloaderPool,
+	pool misc.BufferPool,
 ) *downloadContext {
 	dc := &downloadContext{
 		d:      d,
@@ -581,8 +547,8 @@ func (dc *downloadContext) downloadAdvisory(
 	}
 
 	// Remember the data as we need to store it to file later.
-	data := dc.pool.get()
-	defer dc.pool.put(data)
+	data := dc.pool.Get()
+	defer dc.pool.Put(data)
 	writers = append(writers, data)
 
 	// Download the advisory and hash it.
@@ -781,7 +747,7 @@ func (d *downloader) downloadWorker(
 	label csaf.TLPLabel,
 	files <-chan csaf.AdvisoryFile,
 	errorCh chan<- error,
-	pool downloaderPool,
+	pool misc.BufferPool,
 ) {
 	defer wg.Done()
 

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -283,8 +283,7 @@ func (d *downloader) downloadFiles(
 		}
 	}()
 
-	n := min(d.cfg.Worker, 1)
-
+	n := max(d.cfg.Worker, 1)
 	pool := misc.NewBufferPool(n)
 
 	for range n {

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -288,9 +288,11 @@ func (d *downloader) downloadFiles(
 		n = 1
 	}
 
-	for i := 0; i < n; i++ {
+	pool := newDownloaderPool(n)
+
+	for range n {
 		wg.Add(1)
-		go d.downloadWorker(ctx, &wg, label, advisoryCh, errorCh)
+		go d.downloadWorker(ctx, &wg, label, advisoryCh, errorCh, pool)
 	}
 
 allFiles:
@@ -418,11 +420,43 @@ func (d *downloader) logValidationIssues(url string, errors []string, err error)
 	}
 }
 
+// downloaderPool is a leaky buffer to avoid memory allocations.
+type downloaderPool chan (*bytes.Buffer)
+
+func newDownloaderPool(items int) downloaderPool {
+	return make(downloaderPool, items)
+}
+
+const (
+	minBufSize = 1 * 1024 * 1024
+	maxBufSize = 4 * 1024 * 1024
+)
+
+func (dp downloaderPool) get() *bytes.Buffer {
+	select {
+	case buf := <-dp:
+		return buf
+	default:
+		return bytes.NewBuffer(make([]byte, 0, minBufSize))
+	}
+}
+
+func (dp downloaderPool) put(buf *bytes.Buffer) {
+	if buf.Cap() < maxBufSize { // Throw away if too large.
+		buf.Reset()
+		select {
+		case dp <- buf:
+		default:
+		}
+	}
+}
+
 // downloadContext stores the common context of a downloader.
 type downloadContext struct {
-	d                  *downloader
-	client             util.ClientWithContext
-	data               bytes.Buffer
+	d      *downloader
+	client util.ClientWithContext
+	//data               bytes.Buffer
+	pool               downloaderPool
 	lastDir            string
 	initialReleaseDate time.Time
 	dateExtract        func(any) error
@@ -431,10 +465,15 @@ type downloadContext struct {
 	expr               *util.PathEval
 }
 
-func newDownloadContext(d *downloader, label csaf.TLPLabel) *downloadContext {
+func newDownloadContext(
+	d *downloader,
+	label csaf.TLPLabel,
+	pool downloaderPool,
+) *downloadContext {
 	dc := &downloadContext{
 		d:      d,
 		client: d.httpClient(),
+		pool:   pool,
 		lower:  strings.ToLower(string(label)),
 		expr:   util.NewPathEval(),
 	}
@@ -542,8 +581,9 @@ func (dc *downloadContext) downloadAdvisory(
 	}
 
 	// Remember the data as we need to store it to file later.
-	dc.data.Reset()
-	writers = append(writers, &dc.data)
+	data := dc.pool.get()
+	defer dc.pool.put(data)
+	writers = append(writers, data)
 
 	// Download the advisory and hash it.
 	hasher := io.MultiWriter(writers...)
@@ -591,7 +631,7 @@ func (dc *downloadContext) downloadAdvisory(
 				"error", err)
 		}
 		if sign != nil {
-			if err := dc.d.checkSignature(dc.data.Bytes(), sign); err != nil {
+			if err := dc.d.checkSignature(data.Bytes(), sign); err != nil {
 				if !dc.d.cfg.IgnoreSignatureCheck {
 					dc.stats.signatureFailed++
 					return fmt.Errorf("cannot verify signature for %s: %v", file.URL(), err)
@@ -663,7 +703,7 @@ func (dc *downloadContext) downloadAdvisory(
 	if dc.d.forwarder != nil {
 		dc.d.forwarder.forward(
 			ctx,
-			filename, dc.data.String(),
+			filename, data.String(),
 			valStatus,
 			string(s256Data),
 			string(s512Data))
@@ -717,7 +757,7 @@ func (dc *downloadContext) downloadAdvisory(
 		p string
 		d []byte
 	}{
-		{path, dc.data.Bytes()},
+		{path, data.Bytes()},
 		{path + ".sha256", s256Data},
 		{path + ".sha512", s512Data},
 		{path + ".asc", signData},
@@ -741,10 +781,11 @@ func (d *downloader) downloadWorker(
 	label csaf.TLPLabel,
 	files <-chan csaf.AdvisoryFile,
 	errorCh chan<- error,
+	pool downloaderPool,
 ) {
 	defer wg.Done()
 
-	dc := newDownloadContext(d, label)
+	dc := newDownloadContext(d, label, pool)
 
 	// Add collected stats back to total.
 	defer d.addStats(&dc.stats)

--- a/internal/misc/buffer.go
+++ b/internal/misc/buffer.go
@@ -37,7 +37,8 @@ func (bp BufferPool) Get() *bytes.Buffer {
 
 // Put stores a buffer into the pool.
 func (bp BufferPool) Put(buf *bytes.Buffer) {
-	if buf == nil || buf.Cap() > MaxBufSize { // Throw away if too large.
+	// Throw away if too large.
+	if buf != nil && buf.Cap() <= MaxBufSize {
 		buf.Reset()
 		select {
 		case bp <- buf:

--- a/internal/misc/buffer.go
+++ b/internal/misc/buffer.go
@@ -6,7 +6,7 @@
 // SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
 // Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
 
-package misc
+package misc //revive:disable-line:var-naming
 
 import "bytes"
 

--- a/internal/misc/buffer.go
+++ b/internal/misc/buffer.go
@@ -1,0 +1,47 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+
+package misc
+
+import "bytes"
+
+const (
+	// MinBufSize is the minimal capacity of the pool buffers.
+	MinBufSize = 1 * 1024 * 1024
+	// MaxBufSize is the maximal capacity of the pool buffers.
+	MaxBufSize = 4 * 1024 * 1024
+)
+
+// BufferPool is a pool of reusable buffers.
+type BufferPool chan (*bytes.Buffer)
+
+// NewBufferPool creates a new pool with max number of items.
+func NewBufferPool(items int) BufferPool {
+	return make(BufferPool, items)
+}
+
+// Get returns a buffer from the pool.
+func (bp BufferPool) Get() *bytes.Buffer {
+	select {
+	case buf := <-bp:
+		return buf
+	default:
+		return bytes.NewBuffer(make([]byte, 0, MinBufSize))
+	}
+}
+
+// Put stores a buffer into the pool.
+func (bp BufferPool) Put(buf *bytes.Buffer) {
+	if buf == nil || buf.Cap() <= MaxBufSize { // Throw away if too large.
+		buf.Reset()
+		select {
+		case bp <- buf:
+		default:
+		}
+	}
+}

--- a/internal/misc/buffer.go
+++ b/internal/misc/buffer.go
@@ -37,7 +37,7 @@ func (bp BufferPool) Get() *bytes.Buffer {
 
 // Put stores a buffer into the pool.
 func (bp BufferPool) Put(buf *bytes.Buffer) {
-	if buf == nil || buf.Cap() <= MaxBufSize { // Throw away if too large.
+	if buf == nil || buf.Cap() > MaxBufSize { // Throw away if too large.
 		buf.Reset()
 		select {
 		case bp <- buf:


### PR DESCRIPTION
The checker, dowloader and aggregator are fetching advisories from the net.
To reduce memory strain the memory allocated for one file is hold and re-used
for the next advisories.

The implementation lead to  using more memory than needed. Once a large advisory is
loaded the corresponding large chunk of memory is hold till the end of the program.
Having more downloading workers the problem multiples.

This PR integrates a buffer recycling between downloading workers that only
helds memory blocks up to 4 MiB. Larger chunks are not reused. This is
sensible as larger advisories are rare compared to the majority of small ones.